### PR TITLE
Tableless addition checks

### DIFF
--- a/src/encoding/__init__.py
+++ b/src/encoding/__init__.py
@@ -1,3 +1,4 @@
 from .comparator import *
+from .addition import *
 from .constants import *
 from .utils import *

--- a/src/encoding/addition.py
+++ b/src/encoding/addition.py
@@ -11,6 +11,11 @@ def check_add(
     sum8s: Sequence[U8],
     carry32: Sequence[bool],
 ):
+    """
+    Check the addition of two length 32 8-bit chunks a8s and b8s
+    Items of a8s and b8s should already be verified to be 8 bits before.
+    Overflow is allowed to match the evm behavior
+    """
     assert len(a8s) == len(b8s) == len(sum8s) == 32
     assert len(carry32) == 32
 

--- a/src/encoding/addition.py
+++ b/src/encoding/addition.py
@@ -9,15 +9,15 @@ def check_add(
     a8s: Sequence[U8],
     b8s: Sequence[U8],
     sum8s: Sequence[U8],
-    carry: Sequence[bool],
+    carry32: Sequence[bool],
 ):
     assert len(a8s) == len(b8s) == len(sum8s) == 32
-    assert len(carry) == 32
+    assert len(carry32) == 32
 
     # Before we add anything yet, the carry bit should be 0
     # We allow the last carry bit to be 1 to support the overflow case
-    carry = [0] + carry[:]
+    carry33 = [0] + carry32[:]
 
     for i in range(32):
-        assert carry[i + 1] * (carry[i + 1] - 1) == 0, "carry should be 0 or 1"
-        assert a8s[i] + b8s[i] + carry[i] == sum8s[i] + (carry[i + 1] << 8)
+        assert carry32[i] * (carry32[i] - 1) == 0, "carry should be 0 or 1"
+        assert a8s[i] + b8s[i] + carry33[i] == sum8s[i] + (carry33[i + 1] << 8)

--- a/src/encoding/addition.py
+++ b/src/encoding/addition.py
@@ -1,0 +1,22 @@
+from typing import Sequence
+
+from .utils import is_circuit_code
+from .typing import U8
+
+
+@is_circuit_code
+def check_add(
+    a8s: Sequence[U8],
+    b8s: Sequence[U8],
+    sum8s: Sequence[U8],
+    carry: Sequence[bool],
+):
+    assert len(a8s) == len(b8s) == len(sum8s) == 32
+    assert len(carry) == 32
+
+    # Before we add anything yet, the carry bit should be 0
+    # We allow the last carry bit to be 1 to support the overflow case
+    carry = [0] + carry[:]
+
+    for i in range(32):
+        assert a8s[i] + b8s[i] + carry[i] == sum8s[i] + (carry[i + 1] << 8)

--- a/src/encoding/addition.py
+++ b/src/encoding/addition.py
@@ -19,4 +19,5 @@ def check_add(
     carry = [0] + carry[:]
 
     for i in range(32):
+        assert carry[i + 1] * (carry[i + 1] - 1) == 0, "carry should be 0 or 1"
         assert a8s[i] + b8s[i] + carry[i] == sum8s[i] + (carry[i + 1] << 8)

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -66,18 +66,18 @@ def test_comparator(a, b):
 def test_addition(a, b):
     a8s = u256_to_u8s(a)
     b8s = u256_to_u8s(b)
-    _carry = [0] * 33
+    carry33 = [0] * 33
     sum8s = [0] * 32
     for i in range(32):
-        sum9 = a8s[i] + b8s[i] + _carry[i]
+        sum9 = a8s[i] + b8s[i] + carry33[i]
         sum8s[i] = sum9 % 256
-        _carry[i + 1] = sum9 // 256
+        carry33[i + 1] = sum9 // 256
 
-    carry = _carry[1:]
+    carry32 = carry33[1:]
 
     # Check if the circuit works
-    check_add(a8s, b8s, sum8s, carry)
+    check_add(a8s, b8s, sum8s, carry32)
 
     # Check if the witness works
     sum256 = u8s_to_u256(sum8s)
-    assert a + b == sum256 + (carry[-1] << 256)
+    assert a + b == sum256 + (carry32[-1] << 256)


### PR DESCRIPTION
### What's wrong

Turns out we don't even need table lookup to do 8-bit addition like what we did in #9

### How are we fixing it

Replace the table lookup with the simple linear combinations

