### PR TITLE
add commitment check

### DIFF
--- a/src/encoding/__init__.py
+++ b/src/encoding/__init__.py
@@ -1,4 +1,5 @@
 from .comparator import *
 from .addition import *
+from .commitment import *
 from .constants import *
 from .utils import *

--- a/src/encoding/commitment.py
+++ b/src/encoding/commitment.py
@@ -1,0 +1,43 @@
+from typing import Sequence, Tuple
+
+from typing import Sequence
+from .typing import U256, U8
+from .utils import is_circuit_code, u256_to_u8s
+from .lookup import LookupTable
+
+
+class RangeTable(LookupTable):
+    """
+    This table checks if a and b are both 8 bits.
+    a: 8 bits
+    b: 8 bits
+    (3 columns and 2**16 rows)
+    """
+
+    def __init__(self) -> None:
+        super().__init__(["a", "b"])
+        for a in range(256):
+            for b in range(256):
+                self.add_row(a=a, b=b)
+
+
+def commit(x: U256, random: int) -> Tuple[Tuple[U8, ...], int]:
+    x8s = u256_to_u8s(x)
+    commitment = sum(x8 * random ** i for i, x8 in enumerate(x8s))
+    return x8s, commitment
+
+
+@is_circuit_code
+def check_commitment(x8s: Sequence[U8], commitment: int, random: int, range_table: RangeTable):
+    """
+    We establish that x8s
+    - represents the value we committed before
+    - and all its elements are 8 bits
+    """
+    assert len(x8s) == 32
+
+    assert sum(x8 * random ** i for i, x8 in enumerate(x8s)) == commitment
+
+    for i in range(0, 32, 2):
+        low8, high8 = x8s[i], x8s[i+1]
+        assert range_table.lookup(a=low8, b=high8)

--- a/src/encoding/lookup.py
+++ b/src/encoding/lookup.py
@@ -6,7 +6,7 @@ class LookupTable:
     rows: Set[int]
     random: int
 
-    def __init__(self, columns: Sequence[str], random: int = 123) -> None:
+    def __init__(self, columns: Sequence[str], random: int = 5566) -> None:
         self.columns = set(columns)
         self.rows = set()
         self.random = random

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -1,4 +1,4 @@
-from encoding import u256_to_u8s, u8s_to_u256, compare, SignTable, check_add
+from encoding import u256_to_u8s, u8s_to_u256, compare, SignTable, check_add, check_commitment, RangeTable, commit
 import pytest
 
 
@@ -14,6 +14,22 @@ def test_u256_and_u8s_conversion(u256, u8s):
 
 def test_table_sizes():
     assert len(SignTable()) == 2**18 - 1
+    assert len(RangeTable()) == 2**16
+
+
+@pytest.mark.parametrize("u256", (
+    1,
+    2,
+    511,
+    5566,
+    (1 << 256) - 1,
+    1 << 248,
+))
+def test_check_commitment(u256):
+    range_table = RangeTable()
+    random = 5566
+    x8s, commitment = commit(u256, random)
+    check_commitment(x8s, commitment, random, range_table)
 
 
 NASTY_AB_VALUES = (


### PR DESCRIPTION
### What's wrong

We haven't described the commitment check yet, which checks 
- if an array x8s is an opening of a u256 commitment and 
- if elements in the x8s are all 8 bits.

### How we are fixing it

- Adding the RangeTable for 8-bit value check
- add check_commitment
- and add testings
