### PR TITLE
revamp lookup table and note

### DIFF
--- a/specs/lookup.md
+++ b/specs/lookup.md
@@ -1,0 +1,33 @@
+# Plookup Table
+
+We use the [halo2 lookup table](https://zcash.github.io/halo2/design/proving-system/lookup.html) as a primitive to check if some adviced values are a row of a table.
+
+Example:
+
+This table has columns "a", "b", and "c". Where "a" and "b" are possible combinations of 0, 1, 2. "c" is the logic AND operations on "a" and "b".
+
+| a   | b   | c   |
+| --- | --- | --- |
+| 0   | 0   | 0   |
+| 0   | 1   | 0   |
+| 0   | 2   | 0   |
+| 1   | 0   | 0   |
+| 1   | 1   | 1   |
+| 1   | 2   | 0   |
+| 2   | 0   | 0   |
+| 2   | 1   | 0   |
+| 2   | 2   | 2   |
+
+We can use the table to check the AND operation constraints on some variable x and y in the circuit by proving "x", "y", and "x & y" are cells of a row in the table.
+
+## Fixed Table
+
+Rows of a fixed table are determined "before" proving time.
+
+The AND operation table is an example.
+
+## Variable Table
+
+Rows of a variable table are determined "at" proving time.
+
+It allows prover to create their own table. An example would be the prover can witness a key-value mapping as a variable table. Note that we need extra check to gurantee the uniqueness of the mapping key.

--- a/src/encoding/lookup.py
+++ b/src/encoding/lookup.py
@@ -4,24 +4,27 @@ from typing import Tuple, Sequence, Set
 class LookupTable:
     columns: Tuple[str]
     rows: Set[int]
-    random: int
 
-    def __init__(self, columns: Sequence[str], random: int = 5566) -> None:
+    def __init__(self, columns: Sequence[str]) -> None:
         self.columns = set(columns)
         self.rows = set()
-        self.random = random
 
-    def __compress(self, **kwargs):
-        assert set(kwargs.keys()) == self.columns
-        return sum(kwargs[col] * self.random ** i for i, col in enumerate(self.columns))
+    def __parse_row(self, **kwargs):
+        if len(kwargs.keys()) != len(self.columns):
+            raise ValueError(
+                f"Columns mismatch: expect {self.columns} but got {kwargs.keys()}"
+            )
+        return tuple(kwargs[col] for col in self.columns)
 
     def add_row(self, **kwargs):
-        self.rows.add(self.__compress(**kwargs))
+        row = self.__parse_row(**kwargs)
+        self.rows.add(row)
 
     def __len__(self):
         return len(self.rows)
 
     def lookup(self, **kwargs) -> bool:
-        if self.__compress(**kwargs) in self.rows:
+        row = self.__parse_row(**kwargs)
+        if row in self.rows:
             return True
         raise ValueError("Row does not exist", kwargs)

--- a/src/encoding/lookup.py
+++ b/src/encoding/lookup.py
@@ -3,13 +3,13 @@ from typing import Tuple, Sequence, Set
 
 class LookupTable:
     columns: Tuple[str]
-    rows: Set[int]
+    rows: Set[Tuple[int, ...]]
 
     def __init__(self, columns: Sequence[str]) -> None:
-        self.columns = set(columns)
+        self.columns = tuple(columns)
         self.rows = set()
 
-    def __parse_row(self, **kwargs):
+    def __parse_row(self, **kwargs) -> Tuple[int, ...]:
         if len(kwargs.keys()) != len(self.columns):
             raise ValueError(
                 f"Columns mismatch: expect {self.columns} but got {kwargs.keys()}"


### PR DESCRIPTION
### What's wrong

In the spec, we don't have to specify how the table lookup commitment is actually created. The halo2 API can do this behind the scene. We can just define the table format like columns and rows.

### How are we fixing it

- Remove the compress function in the python code lookup table
- Add a note on lookup table