### PR TITLE
[WIP] Follow `EIP1559` to calculate correct transaction gas price

### DIFF
--- a/src/zkevm_specs/evm/execution/add.py
+++ b/src/zkevm_specs/evm/execution/add.py
@@ -12,7 +12,7 @@ def add(instruction: Instruction):
     c = instruction.stack_push()
 
     instruction.constrain_equal(
-        instruction.add_word(instruction.select(is_sub, c, a), b)[0],
+        instruction.add_words([instruction.select(is_sub, c, a), b])[0],
         instruction.select(is_sub, a, c),
     )
 

--- a/src/zkevm_specs/evm/execution/begin_tx.py
+++ b/src/zkevm_specs/evm/execution/begin_tx.py
@@ -41,7 +41,7 @@ def begin_tx(instruction: Instruction, is_first_step: bool = False):
     instruction.constrain_equal(instruction.add_account_to_access_list(tx_id, tx_callee_address), 1)
 
     # Verify transfer
-    instruction.constrain_transfer(
+    instruction.transfer_with_gas_fee(
         tx_caller_address,
         tx_callee_address,
         tx_value,

--- a/src/zkevm_specs/evm/execution/begin_tx.py
+++ b/src/zkevm_specs/evm/execution/begin_tx.py
@@ -34,7 +34,7 @@ def begin_tx(instruction: Instruction, is_first_step: bool = False):
 
     # TODO: Use intrinsic gas (EIP 2028, 2930)
     gas_left = tx_gas - (53000 if tx_is_create else 21000)
-    instruction.int_to_bytes(gas_left, 8)
+    instruction.constrain_sufficient_gas_left(gas_left)
 
     # Prepare access list of caller and callee
     instruction.constrain_equal(instruction.add_account_to_access_list(tx_id, tx_caller_address), 1)

--- a/src/zkevm_specs/evm/execution/begin_tx.py
+++ b/src/zkevm_specs/evm/execution/begin_tx.py
@@ -26,11 +26,10 @@ def begin_tx(instruction: Instruction, is_first_step: bool = False):
     instruction.constrain_equal(tx_nonce, nonce_prev)
     instruction.constrain_equal(nonce, nonce_prev + 1)
 
-    # TODO: Implement EIP 1559 (currently this assumes gas_fee_cap <= basefee + gas_tip_cap)
     # Calculate gas fee
     tx_gas = instruction.tx_lookup(tx_id, TxContextFieldTag.Gas)
-    tx_gas_fee_cap = instruction.tx_lookup(tx_id, TxContextFieldTag.GasFeeCap)
-    gas_fee, carry = instruction.mul_word_by_u64(tx_gas_fee_cap, tx_gas)
+    tx_gas_price = instruction.tx_gas_price(tx_id)
+    gas_fee, carry = instruction.mul_word_by_u64(tx_gas_price, tx_gas)
     instruction.constrain_zero(carry)
 
     # TODO: Use intrinsic gas (EIP 2028, 2930)

--- a/src/zkevm_specs/evm/instruction.py
+++ b/src/zkevm_specs/evm/instruction.py
@@ -287,7 +287,7 @@ class Instruction:
         self,
         tag: RWTableTag,
         inputs: Sequence[int],
-        is_persistent: bool = True,
+        is_persistent: bool,
     ) -> Array8:
         assert tag.write_only_persistent()
 
@@ -300,8 +300,8 @@ class Instruction:
         self,
         tag: RWTableTag,
         inputs: Sequence[int],
-        is_persistent: bool = True,
-        rw_counter_end_of_reversion: int = 0,
+        is_persistent: bool,
+        rw_counter_end_of_reversion: int,
     ) -> Array8:
         assert tag.write_with_reversion()
 
@@ -360,8 +360,8 @@ class Instruction:
         self,
         account_address: int,
         account_field_tag: AccountFieldTag,
-        is_persistent: bool = True,
-        rw_counter_end_of_reversion: int = 0,
+        is_persistent: bool,
+        rw_counter_end_of_reversion: int,
     ) -> Tuple[int, int]:
         row = self.state_write_with_reversion(
             RWTableTag.Account,
@@ -370,6 +370,46 @@ class Instruction:
             rw_counter_end_of_reversion,
         )
         return row[5], row[6]
+
+    def add_balance(self, account_address: int, values: Sequence[int]):
+        balance, balance_prev = self.account_write(account_address, AccountFieldTag.Balance)
+        result, carry = self.add_words([balance_prev, *values])
+        self.constrain_equal(balance, result)
+        self.constrain_zero(carry)
+
+    def add_balance_with_reversion(
+        self,
+        account_address: int,
+        values: Sequence[int],
+        is_persistent: bool,
+        rw_counter_end_of_reversion: int,
+    ):
+        balance, balance_prev = self.account_write_with_reversion(
+            account_address, AccountFieldTag.Balance, is_persistent, rw_counter_end_of_reversion
+        )
+        result, carry = self.add_words([balance_prev, *values])
+        self.constrain_equal(balance, result)
+        self.constrain_zero(carry)
+
+    def sub_balance(self, account_address: int, values: Sequence[int]):
+        balance, balance_prev = self.account_write(account_address, AccountFieldTag.Balance)
+        result, carry = self.add_words([balance, *values])
+        self.constrain_equal(balance_prev, result)
+        self.constrain_zero(carry)
+
+    def sub_balance_with_reversion(
+        self,
+        account_address: int,
+        values: Sequence[int],
+        is_persistent: bool,
+        rw_counter_end_of_reversion: int,
+    ):
+        balance, balance_prev = self.account_write_with_reversion(
+            account_address, AccountFieldTag.Balance, is_persistent, rw_counter_end_of_reversion
+        )
+        result, carry = self.add_words([balance, *values])
+        self.constrain_equal(balance_prev, result)
+        self.constrain_zero(carry)
 
     def account_read(self, account_address: int, account_field_tag: AccountFieldTag) -> Tuple[int, int]:
         row = self.rw_lookup(RW.Read, RWTableTag.Account, [account_address, account_field_tag])
@@ -391,8 +431,8 @@ class Instruction:
         self,
         tx_id: int,
         account_address: int,
-        is_persistent: bool = True,
-        rw_counter_end_of_reversion: int = 0,
+        is_persistent: bool,
+        rw_counter_end_of_reversion: int,
     ) -> bool:
         row = self.state_write_with_reversion(
             RWTableTag.TxAccessListAccount,
@@ -419,8 +459,8 @@ class Instruction:
         tx_id: int,
         account_address: int,
         storage_slot: int,
-        is_persistent: bool = True,
-        rw_counter_end_of_reversion: int = 0,
+        is_persistent: bool,
+        rw_counter_end_of_reversion: int,
     ) -> bool:
         row = self.state_write_with_reversion(
             RWTableTag.TxAccessListAccount,
@@ -435,21 +475,19 @@ class Instruction:
         sender_address: int,
         receiver_address: int,
         value: int,
-        gas_fee: int = 0,
-        is_persistent: bool = True,
-        rw_counter_end_of_reversion: int = 0,
+        gas_fee: int,
+        is_persistent: bool,
+        rw_counter_end_of_reversion: int,
     ):
-        sender_balance, sender_balance_prev = self.account_write_with_reversion(
-            sender_address, AccountFieldTag.Balance, is_persistent, rw_counter_end_of_reversion
+        self.sub_balance_with_reversion(
+            sender_address,
+            [value, gas_fee],
+            is_persistent,
+            rw_counter_end_of_reversion,
         )
-        receiver_balance, receiver_balance_prev = self.account_write_with_reversion(
-            receiver_address, AccountFieldTag.Balance, is_persistent, rw_counter_end_of_reversion
+        self.add_balance_with_reversion(
+            receiver_address,
+            [value],
+            is_persistent,
+            rw_counter_end_of_reversion,
         )
-
-        result, carry = self.add_words([sender_balance, value, gas_fee])
-        self.constrain_equal(sender_balance_prev, result)
-        self.constrain_zero(carry)
-
-        result, carry = self.add_words([value, receiver_balance_prev])
-        self.constrain_equal(receiver_balance, result)
-        self.constrain_zero(carry)

--- a/src/zkevm_specs/evm/main.py
+++ b/src/zkevm_specs/evm/main.py
@@ -10,10 +10,12 @@ from .execution_state import ExecutionState
 from .instruction import Instruction
 from .step import StepState
 from .table import Tables
+from .typing import Block
 
 
 def verify_steps(
     rlc_store: RLCStore,
+    block: Block,
     tables: Tables,
     steps: Sequence[StepState],
     begin_with_first_step: bool = False,
@@ -21,7 +23,7 @@ def verify_steps(
 ):
     for idx in range(len(steps) - 1):
         verify_step(
-            Instruction(rlc_store=rlc_store, tables=tables, curr=steps[idx], next=steps[idx + 1]),
+            Instruction(rlc_store=rlc_store, block=block, tables=tables, curr=steps[idx], next=steps[idx + 1]),
             begin_with_first_step and idx == 0,
             end_with_final_step and idx == len(steps) - 2,
         )

--- a/src/zkevm_specs/evm/step.py
+++ b/src/zkevm_specs/evm/step.py
@@ -15,13 +15,14 @@ class StepState:
     rw_counter: int
     call_id: int
 
-    # The following 3 fields decide the source of opcode. There are 3 possible
+    # The following 3 fields decide the opcode source. There are 2 possible
     # cases:
-    # 1. Tx contract deployment (is_root and is_create)
-    #   We set opcode_source to tx_id and lookup call_data in tx_table.
-    # 2. CREATE and CREATE2 (not is_root and is_create)
-    #   We set opcode_source to caller_id and lookup memory in rw_table.
-    # 3. Contract execution (not is_create)
+    # 1. Root creation call (is_root and is_create)
+    #   It was planned to set the opcode_source to tx_id, then lookup tx_table's
+    #   CallData field directly, but is still yet to be determined.
+    #   See the issue https://github.com/appliedzkp/zkevm-specs/issues/73 for
+    #   further discussion.
+    # 2. Deployed contract interaction or internal creation call
     #   We set opcode_source to bytecode_hash and lookup bytecode_table.
     is_root: bool
     is_create: bool

--- a/src/zkevm_specs/evm/typing.py
+++ b/src/zkevm_specs/evm/typing.py
@@ -4,6 +4,34 @@ from ..util import U64, U160, U256, Array4, RLCStore, keccak256
 from .table import TxContextFieldTag
 
 
+class Block:
+    coinbase: U160
+    gas_limit: U64
+    block_number: U256
+    time: U256
+    difficulty: U256
+    base_fee: U256
+    block_hashes: Sequence[U256]
+
+    def __init__(
+        self,
+        coinbase: U160 = 0x10,
+        gas_limit: U64 = int(15e6),
+        block_number: U256 = 0,
+        time: U256 = 0,
+        difficulty: U256 = 0,
+        base_fee: U256 = int(1e9),
+        block_hashes: Sequence[U256] = [],
+    ) -> None:
+        self.coinbase = coinbase
+        self.gas_limit = gas_limit
+        self.block_number = block_number
+        self.time = time
+        self.difficulty = difficulty
+        self.base_fee = base_fee
+        self.block_hashes = block_hashes
+
+
 class Transaction:
     id: int
     nonce: U64
@@ -36,6 +64,9 @@ class Transaction:
         self.callee_address = callee_address
         self.value = value
         self.call_data = call_data
+
+    def gas_price(self, base_fee: int) -> int:
+        return min(base_fee + self.gas_tip_cap, self.gas_fee_cap)
 
     def table_assignments(self, rlc_store: RLCStore) -> Sequence[Array4]:
         return [

--- a/src/zkevm_specs/util/__init__.py
+++ b/src/zkevm_specs/util/__init__.py
@@ -4,6 +4,7 @@ from Crypto.Random.random import randrange
 
 from .arithmetic import *
 from .hash import *
+from .param import *
 from .typing import *
 
 

--- a/src/zkevm_specs/util/param.py
+++ b/src/zkevm_specs/util/param.py
@@ -1,0 +1,4 @@
+# Maximun number of bytes with composition value that doesn't wrap around the field
+MAX_N_BYTES = 31
+# Number of bytes of gas
+N_BYTES_GAS = 8

--- a/tests/evm/test_add.py
+++ b/tests/evm/test_add.py
@@ -9,6 +9,7 @@ from zkevm_specs.evm import (
     Tables,
     RWTableTag,
     RW,
+    Block,
     Bytecode,
 )
 from zkevm_specs.util import hex_to_word, rand_bytes, RLCStore
@@ -51,6 +52,7 @@ def test_add(opcode: Opcode, a_bytes: bytes, b_bytes: bytes, c_bytes: Optional[b
 
     verify_steps(
         rlc_store=rlc_store,
+        block=Block(),
         tables=tables,
         steps=[
             StepState(

--- a/tests/evm/test_push.py
+++ b/tests/evm/test_push.py
@@ -8,6 +8,7 @@ from zkevm_specs.evm import (
     Tables,
     RWTableTag,
     RW,
+    Block,
     Bytecode,
 )
 from zkevm_specs.util import rand_bytes, RLCStore
@@ -45,6 +46,7 @@ def test_push(opcode: Opcode, value_be_bytes: bytes):
 
     verify_steps(
         rlc_store=rlc_store,
+        block=Block(),
         tables=tables,
         steps=[
             StepState(


### PR DESCRIPTION
This PR aims to add the missing block constant functionality of `Instruction` and implement `EIP1559` on `BeginTx`.

Currently the block constant can be used directly, just like using the copy constraint in halo2. But the opcode `BLOCKHASH` requires to access up to previous 256 block hashes, which would be expensive to copy 256 value at each step. See more discussion on #75.
