### PR TITLE
Add `block_lookup` in `Instruction` for block constant access

### DIFF
--- a/src/zkevm_specs/evm/table.py
+++ b/src/zkevm_specs/evm/table.py
@@ -221,14 +221,14 @@ class Tables:
 
     # Each row in BlockTable contains:
     # - tag
-    # - block_number_or_zero
+    # - block_number_or_zero (meaningful only for BlockHash, will be zero for other tags)
     # - value
-    block_table: Set[Array4]
+    block_table: Set[Array3]
 
     # Each row in TxTable contains:
     # - tx_id
     # - tag
-    # - index_or_zero
+    # - index_or_zero (meaningful only for CallData, will be zero for other tags)
     # - value
     tx_table: Set[Array4]
 

--- a/src/zkevm_specs/evm/typing.py
+++ b/src/zkevm_specs/evm/typing.py
@@ -13,9 +13,9 @@ class Block:
     difficulty: U256
     base_fee: U256
 
-    # previous_block_hashes contains at most previous 256 block hashes, where
-    # the lastest one is at previous_block_hashes[-1].
-    previous_block_hashes: Sequence[U256]
+    # history_hashes contains most recent 256 block hashes in history, where
+    # the lastest one is at history_hashes[-1].
+    history_hashes: Sequence[U256]
 
     def __init__(
         self,
@@ -25,9 +25,9 @@ class Block:
         time: U256 = 0,
         difficulty: U256 = 0,
         base_fee: U256 = int(1e9),
-        previous_block_hashes: Sequence[U256] = [],
+        history_hashes: Sequence[U256] = [],
     ) -> None:
-        assert len(previous_block_hashes) <= 256
+        assert len(history_hashes) <= 256
 
         self.coinbase = coinbase
         self.gas_limit = gas_limit
@@ -35,7 +35,7 @@ class Block:
         self.time = time
         self.difficulty = difficulty
         self.base_fee = base_fee
-        self.previous_block_hashes = previous_block_hashes
+        self.history_hashes = history_hashes
 
     def table_assignments(self, rlc_store: RLCStore) -> Sequence[Array3]:
         return [
@@ -47,7 +47,7 @@ class Block:
             (BlockContextFieldTag.BaseFee, 0, rlc_store.to_rlc(self.base_fee, 32)),
         ] + [
             (BlockContextFieldTag.BlockHash, self.block_number + idx - 1, rlc_store.to_rlc(block_hash, 32))
-            for idx, block_hash in enumerate(reversed(self.previous_block_hashes))
+            for idx, block_hash in enumerate(reversed(self.history_hashes))
         ]
 
 

--- a/src/zkevm_specs/evm/typing.py
+++ b/src/zkevm_specs/evm/typing.py
@@ -1,8 +1,54 @@
 from typing import Iterator, Optional, Sequence, Union
 
-from ..util import U64, U160, U256, Array4, RLCStore, keccak256
-from .table import TxContextFieldTag
+from ..util import U64, U160, U256, Array3, Array4, RLCStore, keccak256
+from .table import BlockContextFieldTag, TxContextFieldTag
 from .opcode import get_push_size
+
+
+class Block:
+    coinbase: U160
+    gas_limit: U64
+    block_number: U256
+    time: U256
+    difficulty: U256
+    base_fee: U256
+
+    # previous_block_hashes contains at most previous 256 block hashes, where
+    # the lastest one is at previous_block_hashes[-1].
+    previous_block_hashes: Sequence[U256]
+
+    def __init__(
+        self,
+        coinbase: U160 = 0x10,
+        gas_limit: U64 = int(15e6),
+        block_number: U256 = 0,
+        time: U256 = 0,
+        difficulty: U256 = 0,
+        base_fee: U256 = int(1e9),
+        previous_block_hashes: Sequence[U256] = [],
+    ) -> None:
+        assert len(previous_block_hashes) <= 256
+
+        self.coinbase = coinbase
+        self.gas_limit = gas_limit
+        self.block_number = block_number
+        self.time = time
+        self.difficulty = difficulty
+        self.base_fee = base_fee
+        self.previous_block_hashes = previous_block_hashes
+
+    def table_assignments(self, rlc_store: RLCStore) -> Sequence[Array3]:
+        return [
+            (BlockContextFieldTag.Coinbase, 0, self.coinbase),
+            (BlockContextFieldTag.GasLimit, 0, self.gas_limit),
+            (BlockContextFieldTag.BlockNumber, 0, rlc_store.to_rlc(self.block_number, 32)),
+            (BlockContextFieldTag.Time, 0, rlc_store.to_rlc(self.time, 32)),
+            (BlockContextFieldTag.Difficulty, 0, rlc_store.to_rlc(self.difficulty, 32)),
+            (BlockContextFieldTag.BaseFee, 0, rlc_store.to_rlc(self.base_fee, 32)),
+        ] + [
+            (BlockContextFieldTag.BlockHash, self.block_number + idx - 1, rlc_store.to_rlc(block_hash, 32))
+            for idx, block_hash in enumerate(reversed(self.previous_block_hashes))
+        ]
 
 
 class Transaction:

--- a/src/zkevm_specs/util/__init__.py
+++ b/src/zkevm_specs/util/__init__.py
@@ -4,6 +4,7 @@ from Crypto.Random.random import randrange
 
 from .arithmetic import *
 from .hash import *
+from .param import *
 from .typing import *
 
 

--- a/src/zkevm_specs/util/arithmetic.py
+++ b/src/zkevm_specs/util/arithmetic.py
@@ -2,6 +2,8 @@ from typing import Dict, Sequence, Tuple, Union
 from Crypto.Random import get_random_bytes
 from Crypto.Random.random import randrange
 
+from .param import MAX_N_BYTES
+
 
 # BN254 scalar field size
 FP_MODULUS = 21888242871839275222246405745257275088548364400416034343698204186575808495617
@@ -20,7 +22,7 @@ def fp_inv(value: int) -> int:
 
 
 def le_to_int(bytes: Sequence[int]) -> int:
-    assert len(bytes) <= 31, "too many bytes to composite an integer in field"
+    assert len(bytes) <= MAX_N_BYTES, "too many bytes to composite an integer in field"
     return linear_combine(bytes, 256)
 
 

--- a/src/zkevm_specs/util/param.py
+++ b/src/zkevm_specs/util/param.py
@@ -1,0 +1,2 @@
+# Maximun number of bytes with composition value that doesn't wrap around the field
+MAX_N_BYTES = 31

--- a/tests/evm/test_add.py
+++ b/tests/evm/test_add.py
@@ -9,6 +9,7 @@ from zkevm_specs.evm import (
     Tables,
     RWTableTag,
     RW,
+    Block,
     Bytecode,
 )
 from zkevm_specs.util import hex_to_word, rand_bytes, RLCStore
@@ -34,10 +35,12 @@ def test_add(opcode: Opcode, a_bytes: bytes, b_bytes: bytes, c_bytes: Optional[b
         else (rlc_store.add(a, b) if opcode == Opcode.ADD else rlc_store.sub(a, b))[0]
     )
 
+    block = Block()
     bytecode = Bytecode(f"7f{b_bytes.hex()}7f{a_bytes.hex()}{opcode.hex()}00")
     bytecode_hash = rlc_store.to_rlc(bytecode.hash, 32)
 
     tables = Tables(
+        block_table=set(block.table_assignments(rlc_store)),
         tx_table=set(),
         bytecode_table=set(bytecode.table_assignments(rlc_store)),
         rw_table=set(

--- a/tests/evm/test_begin_tx.py
+++ b/tests/evm/test_begin_tx.py
@@ -9,6 +9,7 @@ from zkevm_specs.evm import (
     RW,
     AccountFieldTag,
     CallContextFieldTag,
+    Block,
     Transaction,
     Bytecode,
 )
@@ -38,6 +39,7 @@ TESTING_DATA = (
 def test_begin_tx(tx: Transaction, result: bool):
     rlc_store = RLCStore()
 
+    block = Block()
     caller_balance_prev = rlc_store.to_rlc(int(1e20), 32)
     callee_balance_prev = rlc_store.to_rlc(0, 32)
     caller_balance = rlc_store.to_rlc(int(1e20) - (tx.value + tx.gas * tx.gas_fee_cap), 32)
@@ -47,6 +49,7 @@ def test_begin_tx(tx: Transaction, result: bool):
     bytecode_hash = rlc_store.to_rlc(bytecode.hash, 32)
 
     tables = Tables(
+        block_table=set(block.table_assignments(rlc_store)),
         tx_table=set(tx.table_assignments(rlc_store)),
         bytecode_table=set(bytecode.table_assignments(rlc_store)),
         rw_table=set(

--- a/tests/evm/test_jump.py
+++ b/tests/evm/test_jump.py
@@ -9,6 +9,7 @@ from zkevm_specs.evm import (
     Tables,
     RWTableTag,
     RW,
+    Block,
     Bytecode,
 )
 from zkevm_specs.util import hex_to_word, rand_bytes, RLCStore
@@ -22,12 +23,14 @@ def test_jump(opcode: Opcode, dest_bytes: bytes):
     rlc_store = RLCStore()
     dest = rlc_store.to_rlc(bytes(reversed(dest_bytes)))
 
+    block = Block()
     # Jumps to PC=7
     # PUSH1 80 PUSH1 40 PUSH1 07 JUMP JUMPDEST STOP
     bytecode = Bytecode(f"6080604060{dest_bytes.hex()}565b00")
     bytecode_hash = rlc_store.to_rlc(bytecode.hash, 32)
 
     tables = Tables(
+        block_table=set(block.table_assignments(rlc_store)),
         tx_table=set(),
         bytecode_table=set(bytecode.table_assignments(rlc_store)),
         rw_table=set(

--- a/tests/evm/test_jumpi.py
+++ b/tests/evm/test_jumpi.py
@@ -9,6 +9,7 @@ from zkevm_specs.evm import (
     Tables,
     RWTableTag,
     RW,
+    Block,
     Bytecode,
 )
 from zkevm_specs.util import hex_to_word, rand_bytes, RLCStore
@@ -23,12 +24,14 @@ def test_jumpi_cond_nonzero(opcode: Opcode, cond_bytes: bytes, dest_bytes: bytes
     cond = rlc_store.to_rlc(bytes(reversed(cond_bytes)))
     dest = rlc_store.to_rlc(bytes(reversed(dest_bytes)))
 
+    block = Block()
     # Jumps to PC=7 because the condition (40) is nonzero.
     # PUSH1 80 PUSH1 40 PUSH1 07 JUMPI JUMPDEST STOP
     bytecode = Bytecode(f"6080604060{dest_bytes.hex()}575b00")
     bytecode_hash = rlc_store.to_rlc(bytecode.hash, 32)
 
     tables = Tables(
+        block_table=set(block.table_assignments(rlc_store)),
         tx_table=set(),
         bytecode_table=set(bytecode.table_assignments(rlc_store)),
         rw_table=set(
@@ -78,12 +81,14 @@ def test_jumpi_cond_zero(opcode: Opcode, cond_bytes: bytes, dest_bytes: bytes):
     cond = rlc_store.to_rlc(bytes(reversed(cond_bytes)))
     dest = rlc_store.to_rlc(bytes(reversed(dest_bytes)))
 
+    block = Block()
     # Jumps to PC=7 because the condition (0) is zero.
     # PUSH1 80 PUSH1 0 PUSH1 08 JUMPI STOP
     bytecode = Bytecode(f"6080600060{dest_bytes.hex()}575b00")
     bytecode_hash = rlc_store.to_rlc(bytecode.hash, 32)
 
     tables = Tables(
+        block_table=set(block.table_assignments(rlc_store)),
         tx_table=set(),
         bytecode_table=set(bytecode.table_assignments(rlc_store)),
         rw_table=set(

--- a/tests/evm/test_push.py
+++ b/tests/evm/test_push.py
@@ -8,6 +8,7 @@ from zkevm_specs.evm import (
     Tables,
     RWTableTag,
     RW,
+    Block,
     Bytecode,
 )
 from zkevm_specs.util import rand_bytes, RLCStore
@@ -30,10 +31,12 @@ def test_push(opcode: Opcode, value_be_bytes: bytes):
 
     value = rlc_store.to_rlc(bytes(reversed(value_be_bytes)))
 
+    block = Block()
     bytecode = Bytecode(f"{opcode.hex()}{value_be_bytes.hex()}00")
     bytecode_hash = rlc_store.to_rlc(bytecode.hash, 32)
 
     tables = Tables(
+        block_table=set(block.table_assignments(rlc_store)),
         tx_table=set(),
         bytecode_table=set(bytecode.table_assignments(rlc_store)),
         rw_table=set(


### PR DESCRIPTION
This PR aims to add the missing block constant functionality of `Instruction`.

It adds a `block_table` to store all static block constant and up to previous 256 block hashes for block constant lookup. The table in real implementation could share the same instance columns with `tx_table` once they are properly separate by selectors.

This approach targets a straightforward implementation, in the future we could also adopt `EIP2935` mentioned in #75 to totally remove `block_table`.