### PR TITLE
Use legacy transaction format and defer support of dynamic gas price

### DIFF
--- a/src/zkevm_specs/evm/execution/add.py
+++ b/src/zkevm_specs/evm/execution/add.py
@@ -12,7 +12,7 @@ def add(instruction: Instruction):
     c = instruction.stack_push()
 
     instruction.constrain_equal(
-        instruction.add_word(instruction.select(is_sub, c, a), b)[0],
+        instruction.add_words([instruction.select(is_sub, c, a), b])[0],
         instruction.select(is_sub, a, c),
     )
 

--- a/src/zkevm_specs/evm/execution/begin_tx.py
+++ b/src/zkevm_specs/evm/execution/begin_tx.py
@@ -26,11 +26,11 @@ def begin_tx(instruction: Instruction, is_first_step: bool = False):
     instruction.constrain_equal(tx_nonce, nonce_prev)
     instruction.constrain_equal(nonce, nonce_prev + 1)
 
-    # TODO: Implement EIP 1559 (currently this assumes gas_fee_cap <= basefee + gas_tip_cap)
+    # TODO: Implement EIP 1559 (currently it supports legacy transaction format)
     # Calculate gas fee
     tx_gas = instruction.tx_lookup(tx_id, TxContextFieldTag.Gas)
-    tx_gas_fee_cap = instruction.tx_lookup(tx_id, TxContextFieldTag.GasFeeCap)
-    gas_fee, carry = instruction.mul_word_by_u64(tx_gas_fee_cap, tx_gas)
+    tx_gas_price = instruction.tx_lookup(tx_id, TxContextFieldTag.GasPrice)
+    gas_fee, carry = instruction.mul_word_by_u64(tx_gas_price, tx_gas)
     instruction.constrain_zero(carry)
 
     # TODO: Use intrinsic gas (EIP 2028, 2930)

--- a/src/zkevm_specs/evm/execution/begin_tx.py
+++ b/src/zkevm_specs/evm/execution/begin_tx.py
@@ -42,7 +42,7 @@ def begin_tx(instruction: Instruction, is_first_step: bool = False):
     instruction.constrain_equal(instruction.add_account_to_access_list(tx_id, tx_callee_address), 1)
 
     # Verify transfer
-    instruction.constrain_transfer(
+    instruction.transfer_with_gas_fee(
         tx_caller_address,
         tx_callee_address,
         tx_value,

--- a/src/zkevm_specs/evm/execution/begin_tx.py
+++ b/src/zkevm_specs/evm/execution/begin_tx.py
@@ -36,7 +36,7 @@ def begin_tx(instruction: Instruction, is_first_step: bool = False):
     # TODO: Handle gas cost of tx level access list (EIP 2930)
     tx_call_data_gas_cost = instruction.tx_lookup(tx_id, TxContextFieldTag.CallDataGasCost)
     gas_left = tx_gas - (53000 if tx_is_create else 21000) - tx_call_data_gas_cost
-    instruction.constrain_sufficient_gas_left(gas_left)
+    instruction.constrain_gas_left_not_underflow(gas_left)
 
     # Prepare access list of caller and callee
     instruction.constrain_equal(instruction.add_account_to_access_list(tx_id, tx_caller_address), 1)

--- a/src/zkevm_specs/evm/execution/begin_tx.py
+++ b/src/zkevm_specs/evm/execution/begin_tx.py
@@ -33,8 +33,9 @@ def begin_tx(instruction: Instruction, is_first_step: bool = False):
     gas_fee, carry = instruction.mul_word_by_u64(tx_gas_price, tx_gas)
     instruction.constrain_zero(carry)
 
-    # TODO: Use intrinsic gas (EIP 2028, 2930)
-    gas_left = tx_gas - (53000 if tx_is_create else 21000)
+    # TODO: Handle gas cost of tx level access list (EIP 2930)
+    tx_call_data_gas_cost = instruction.tx_lookup(tx_id, TxContextFieldTag.CallDataGasCost)
+    gas_left = tx_gas - (53000 if tx_is_create else 21000) - tx_call_data_gas_cost
     instruction.constrain_sufficient_gas_left(gas_left)
 
     # Prepare access list of caller and callee

--- a/src/zkevm_specs/evm/execution/begin_tx.py
+++ b/src/zkevm_specs/evm/execution/begin_tx.py
@@ -35,7 +35,7 @@ def begin_tx(instruction: Instruction, is_first_step: bool = False):
 
     # TODO: Use intrinsic gas (EIP 2028, 2930)
     gas_left = tx_gas - (53000 if tx_is_create else 21000)
-    instruction.int_to_bytes(gas_left, 8)
+    instruction.constrain_sufficient_gas_left(gas_left)
 
     # Prepare access list of caller and callee
     instruction.constrain_equal(instruction.add_account_to_access_list(tx_id, tx_caller_address), 1)

--- a/src/zkevm_specs/evm/instruction.py
+++ b/src/zkevm_specs/evm/instruction.py
@@ -90,14 +90,11 @@ class Instruction:
             receiver_address, AccountFieldTag.Balance, is_persistent, rw_counter_end_of_reversion
         )
 
-        value_with_gas_fee, overflow = self.add_word(value, gas_fee)
-        self.constrain_zero(overflow)
-
-        result, carry = self.add_word(value_with_gas_fee, sender_balance)
+        result, carry = self.add_words([sender_balance, value, gas_fee])
         self.constrain_equal(sender_balance_prev, result)
         self.constrain_zero(carry)
 
-        result, carry = self.add_word(value, receiver_balance_prev)
+        result, carry = self.add_words([value, receiver_balance_prev])
         self.constrain_equal(receiver_balance, result)
         self.constrain_zero(carry)
 
@@ -197,20 +194,18 @@ class Instruction:
     def pair_select(self, value: int, lhs: int, rhs: int) -> Tuple[bool, bool]:
         return value == lhs, value == rhs
 
-    def add_word(self, a: int, b: int) -> Tuple[int, bool]:
-        a_bytes = self.rlc_to_bytes(a, 32)
-        b_bytes = self.rlc_to_bytes(b, 32)
+    def add_words(self, addends: Sequence[int]) -> Tuple[int, int]:
+        def rlc_to_lo_hi(rlc: int) -> Tuple[Sequence[int], Sequence[int]]:
+            bytes = self.rlc_to_bytes(rlc, 32)
+            return self.bytes_to_int(bytes[:16]), self.bytes_to_int(bytes[16:])
 
-        a_lo = self.bytes_to_int(a_bytes[:16])
-        a_hi = self.bytes_to_int(a_bytes[16:])
-        b_lo = self.bytes_to_int(b_bytes[:16])
-        b_hi = self.bytes_to_int(b_bytes[16:])
-        carry_lo, c_lo = divmod(a_lo + b_lo, 1 << 128)
-        carry_hi, c_hi = divmod(a_hi + b_hi + carry_lo, 1 << 128)
+        addends_lo, addends_hi = list(zip(*map(rlc_to_lo_hi, addends)))
+        carry_lo, sum_lo = divmod(sum(addends_lo), 1 << 128)
+        carry_hi, sum_hi = divmod(sum(addends_hi) + carry_lo, 1 << 128)
 
-        c_bytes = c_lo.to_bytes(16, "little") + c_hi.to_bytes(16, "little")
+        sum_bytes = sum_lo.to_bytes(16, "little") + sum_hi.to_bytes(16, "little")
 
-        return self.rlc_store.to_rlc(c_bytes), carry_hi
+        return self.rlc_store.to_rlc(sum_bytes), carry_hi
 
     def mul_word_by_u64(self, multiplicand: int, multiplier: int) -> Tuple[int, int]:
         multiplicand_bytes = self.rlc_to_bytes(multiplicand, 32)
@@ -260,6 +255,20 @@ class Instruction:
     def bytecode_lookup(self, bytecode_hash: int, index: int, is_code: int) -> int:
         return self.tables.bytecode_lookup([bytecode_hash, index, Tables._, is_code])[2]
 
+    def opcode_lookup(self, is_code: bool) -> int:
+        index = self.curr.program_counter + self.program_counter_offset
+        self.program_counter_offset += 1
+
+        return self.opcode_lookup_at(index, is_code)
+
+    def opcode_lookup_at(self, index: int, is_code: bool) -> int:
+        if self.curr.is_root and self.curr.is_create:
+            raise NotImplementedError(
+                "The opcode source when is_root and is_create (root creation call) is not determined yet"
+            )
+        else:
+            return self.bytecode_lookup(self.curr.opcode_source, index, is_code)
+
     def rw_lookup(self, rw: RW, tag: RWTableTag, inputs: Sequence[int], rw_counter: Optional[int] = None) -> Array8:
         if rw_counter is None:
             rw_counter = self.curr.rw_counter + self.rw_counter_offset
@@ -308,20 +317,6 @@ class Instruction:
             self.rw_lookup(RW.Write, tag, inputs, rw_counter=rw_counter)
 
         return row
-
-    def opcode_lookup(self, is_code: bool) -> int:
-        index = self.curr.program_counter + self.program_counter_offset
-        self.program_counter_offset += 1
-
-        return self.opcode_lookup_at(index, is_code)
-
-    def opcode_lookup_at(self, index: int, is_code: bool) -> int:
-        if self.curr.is_root and self.curr.is_create:
-            raise NotImplementedError(
-                "The opcode source when is_root and is_create (root creation call) is not determined yet"
-            )
-        else:
-            return self.bytecode_lookup(self.curr.opcode_source, index, is_code)
 
     def call_context_lookup(self, tag: CallContextFieldTag, rw: RW = RW.Read, call_id: Union[int, None] = None) -> int:
         if call_id is None:

--- a/src/zkevm_specs/evm/instruction.py
+++ b/src/zkevm_specs/evm/instruction.py
@@ -74,7 +74,7 @@ class Instruction:
     def constrain_bool(self, value: int):
         assert value in [0, 1]
 
-    def constrain_sufficient_gas_left(self, gas_left: int):
+    def constrain_gas_left_not_underflow(self, gas_left: int):
         self.int_to_bytes(gas_left, N_BYTES_GAS)
 
     def constrain_state_transition(self, **kwargs: Transition):
@@ -148,7 +148,7 @@ class Instruction:
     ):
         gas_cost = Opcode(opcode).constant_gas_cost() + dynamic_gas_cost
 
-        self.constrain_sufficient_gas_left(self.curr.gas_left - gas_cost)
+        self.constrain_gas_left_not_underflow(self.curr.gas_left - gas_cost)
         self.constrain_state_transition(
             rw_counter=rw_counter,
             program_counter=program_counter,

--- a/src/zkevm_specs/evm/step.py
+++ b/src/zkevm_specs/evm/step.py
@@ -15,13 +15,14 @@ class StepState:
     rw_counter: int
     call_id: int
 
-    # The following 3 fields decide the source of opcode. There are 3 possible
+    # The following 3 fields decide the opcode source. There are 2 possible
     # cases:
-    # 1. Tx contract deployment (is_root and is_create)
-    #   We set opcode_source to tx_id and lookup call_data in tx_table.
-    # 2. CREATE and CREATE2 (not is_root and is_create)
-    #   We set opcode_source to caller_id and lookup memory in rw_table.
-    # 3. Contract execution (not is_create)
+    # 1. Root creation call (is_root and is_create)
+    #   It was planned to set the opcode_source to tx_id, then lookup tx_table's
+    #   CallData field directly, but is still yet to be determined.
+    #   See the issue https://github.com/appliedzkp/zkevm-specs/issues/73 for
+    #   further discussion.
+    # 2. Deployed contract interaction or internal creation call
     #   We set opcode_source to bytecode_hash and lookup bytecode_table.
     is_root: bool
     is_create: bool

--- a/src/zkevm_specs/evm/table.py
+++ b/src/zkevm_specs/evm/table.py
@@ -72,6 +72,7 @@ class TxContextFieldTag(IntEnum):
     IsCreate = auto()
     Value = auto()
     CallDataLength = auto()
+    CallDataGasCost = auto()
     CallData = auto()
 
 

--- a/src/zkevm_specs/evm/table.py
+++ b/src/zkevm_specs/evm/table.py
@@ -60,12 +60,13 @@ class TxContextFieldTag(IntEnum):
     """
     Tag for TxTable lookup, where the TxTable is an instance-column table where
     part of it will be built by verifier.
+    Note that the field here is targeting legacy transaction format, supporting
+    of EIP1559 is deferred to future work.
     """
 
     Nonce = auto()
     Gas = auto()
-    GasTipCap = auto()
-    GasFeeCap = auto()
+    GasPrice = auto()
     CallerAddress = auto()
     CalleeAddress = auto()
     IsCreate = auto()

--- a/src/zkevm_specs/evm/typing.py
+++ b/src/zkevm_specs/evm/typing.py
@@ -55,8 +55,7 @@ class Transaction:
     id: int
     nonce: U64
     gas: U64
-    gas_tip_cap: U256
-    gas_fee_cap: U256
+    gas_price: U256
     caller_address: U160
     callee_address: Optional[U160]
     value: U256
@@ -67,8 +66,7 @@ class Transaction:
         id: int = 1,
         nonce: U64 = 0,
         gas: U64 = 21000,
-        gas_tip_cap: U256 = int(1e9),
-        gas_fee_cap: U256 = int(2e9),
+        gas_price: U256 = int(2e9),
         caller_address: U160 = 0,
         callee_address: Optional[U160] = None,
         value: U256 = 0,
@@ -77,8 +75,7 @@ class Transaction:
         self.id = id
         self.nonce = nonce
         self.gas = gas
-        self.gas_tip_cap = gas_tip_cap
-        self.gas_fee_cap = gas_fee_cap
+        self.gas_price = gas_price
         self.caller_address = caller_address
         self.callee_address = callee_address
         self.value = value
@@ -88,8 +85,7 @@ class Transaction:
         return [
             (self.id, TxContextFieldTag.Nonce, 0, self.nonce),
             (self.id, TxContextFieldTag.Gas, 0, self.gas),
-            (self.id, TxContextFieldTag.GasTipCap, 0, rlc_store.to_rlc(self.gas_tip_cap, 32)),
-            (self.id, TxContextFieldTag.GasFeeCap, 0, rlc_store.to_rlc(self.gas_fee_cap, 32)),
+            (self.id, TxContextFieldTag.GasPrice, 0, rlc_store.to_rlc(self.gas_price, 32)),
             (self.id, TxContextFieldTag.CallerAddress, 0, self.caller_address),
             (self.id, TxContextFieldTag.CalleeAddress, 0, self.callee_address),
             (self.id, TxContextFieldTag.IsCreate, 0, self.callee_address is None),

--- a/src/zkevm_specs/evm/typing.py
+++ b/src/zkevm_specs/evm/typing.py
@@ -1,6 +1,18 @@
 from typing import Iterator, Optional, Sequence, Union
+from functools import reduce
+from itertools import chain
 
-from ..util import U64, U160, U256, Array3, Array4, RLCStore, keccak256
+from ..util import (
+    U64,
+    U160,
+    U256,
+    Array3,
+    Array4,
+    RLCStore,
+    keccak256,
+    GAS_COST_TX_CALL_DATA_PER_NON_ZERO_BYTE,
+    GAS_COST_TX_CALL_DATA_PER_ZERO_BYTE,
+)
 from .table import BlockContextFieldTag, TxContextFieldTag
 from .opcode import get_push_size
 
@@ -81,17 +93,25 @@ class Transaction:
         self.value = value
         self.call_data = call_data
 
-    def table_assignments(self, rlc_store: RLCStore) -> Sequence[Array4]:
-        return [
-            (self.id, TxContextFieldTag.Nonce, 0, self.nonce),
-            (self.id, TxContextFieldTag.Gas, 0, self.gas),
-            (self.id, TxContextFieldTag.GasPrice, 0, rlc_store.to_rlc(self.gas_price, 32)),
-            (self.id, TxContextFieldTag.CallerAddress, 0, self.caller_address),
-            (self.id, TxContextFieldTag.CalleeAddress, 0, self.callee_address),
-            (self.id, TxContextFieldTag.IsCreate, 0, self.callee_address is None),
-            (self.id, TxContextFieldTag.Value, 0, rlc_store.to_rlc(self.value, 32)),
-            (self.id, TxContextFieldTag.CallDataLength, 0, len(self.call_data)),
-        ] + [(self.id, TxContextFieldTag.CallData, idx, byte) for idx, byte in enumerate(self.call_data)]
+    def table_assignments(self, rlc_store: RLCStore) -> Iterator[Array4]:
+        def call_data_gas_cost_per_byte(byte: int):
+            return GAS_COST_TX_CALL_DATA_PER_ZERO_BYTE if byte is 0 else GAS_COST_TX_CALL_DATA_PER_NON_ZERO_BYTE
+
+        call_data_gas_cost = reduce(lambda acc, byte: acc + call_data_gas_cost_per_byte(byte), self.call_data, 0)
+        return chain(
+            [
+                (self.id, TxContextFieldTag.Nonce, 0, self.nonce),
+                (self.id, TxContextFieldTag.Gas, 0, self.gas),
+                (self.id, TxContextFieldTag.GasPrice, 0, rlc_store.to_rlc(self.gas_price, 32)),
+                (self.id, TxContextFieldTag.CallerAddress, 0, self.caller_address),
+                (self.id, TxContextFieldTag.CalleeAddress, 0, self.callee_address),
+                (self.id, TxContextFieldTag.IsCreate, 0, self.callee_address is None),
+                (self.id, TxContextFieldTag.Value, 0, rlc_store.to_rlc(self.value, 32)),
+                (self.id, TxContextFieldTag.CallDataLength, 0, len(self.call_data)),
+                (self.id, TxContextFieldTag.CallDataGasCost, 0, call_data_gas_cost),
+            ],
+            map(lambda item: (self.id, TxContextFieldTag.CallData, item[0], item[1]), enumerate(self.call_data)),
+        )
 
 
 class Bytecode:

--- a/src/zkevm_specs/util/param.py
+++ b/src/zkevm_specs/util/param.py
@@ -1,2 +1,4 @@
 # Maximun number of bytes with composition value that doesn't wrap around the field
 MAX_N_BYTES = 31
+# Number of bytes of gas
+N_BYTES_GAS = 8

--- a/src/zkevm_specs/util/param.py
+++ b/src/zkevm_specs/util/param.py
@@ -2,3 +2,8 @@
 MAX_N_BYTES = 31
 # Number of bytes of gas
 N_BYTES_GAS = 8
+
+# Gas cost of transaction call_data per non-zero byte
+GAS_COST_TX_CALL_DATA_PER_NON_ZERO_BYTE = 16
+# Gas cost of transaction call_data per zero byte
+GAS_COST_TX_CALL_DATA_PER_ZERO_BYTE = 4

--- a/tests/evm/test_begin_tx.py
+++ b/tests/evm/test_begin_tx.py
@@ -20,16 +20,12 @@ TESTING_DATA = (
     (Transaction(caller_address=0xFE, callee_address=0xFF, value=int(1e18)), False),
     (Transaction(caller_address=rand_address(), callee_address=rand_address(), value=rand_range(1e20)), True),
     (
-        Transaction(
-            caller_address=rand_address(), callee_address=rand_address(), gas_fee_cap=rand_range(42857142857143)
-        ),
+        Transaction(caller_address=rand_address(), callee_address=rand_address(), gas_price=rand_range(42857142857143)),
         True,
     ),
     (Transaction(caller_address=rand_address(), callee_address=rand_address(), value=rand_range(1e20)), False),
     (
-        Transaction(
-            caller_address=rand_address(), callee_address=rand_address(), gas_fee_cap=rand_range(42857142857143)
-        ),
+        Transaction(caller_address=rand_address(), callee_address=rand_address(), gas_price=rand_range(42857142857143)),
         False,
     ),
 )
@@ -42,7 +38,7 @@ def test_begin_tx(tx: Transaction, result: bool):
     block = Block()
     caller_balance_prev = rlc_store.to_rlc(int(1e20), 32)
     callee_balance_prev = rlc_store.to_rlc(0, 32)
-    caller_balance = rlc_store.to_rlc(int(1e20) - (tx.value + tx.gas * tx.gas_fee_cap), 32)
+    caller_balance = rlc_store.to_rlc(int(1e20) - (tx.value + tx.gas * tx.gas_price), 32)
     callee_balance = rlc_store.to_rlc(tx.value, 32)
 
     bytecode = Bytecode("00")

--- a/tests/evm/test_begin_tx.py
+++ b/tests/evm/test_begin_tx.py
@@ -16,18 +16,26 @@ from zkevm_specs.evm import (
 from zkevm_specs.util import RLCStore, rand_address, rand_range
 
 TESTING_DATA = (
+    # Transfer 1 ether, successfully
     (Transaction(caller_address=0xFE, callee_address=0xFF, value=int(1e18)), True),
+    # Transfer 1 ether, tx reverts
     (Transaction(caller_address=0xFE, callee_address=0xFF, value=int(1e18)), False),
+    # Transfer random ether, successfully
     (Transaction(caller_address=rand_address(), callee_address=rand_address(), value=rand_range(1e20)), True),
+    # Transfer nothing with random gas_price, successfully
     (
         Transaction(caller_address=rand_address(), callee_address=rand_address(), gas_price=rand_range(42857142857143)),
         True,
     ),
+    # Transfer random ether, tx reverts
     (Transaction(caller_address=rand_address(), callee_address=rand_address(), value=rand_range(1e20)), False),
+    # Transfer nothing with random gas_price, tx reverts
     (
         Transaction(caller_address=rand_address(), callee_address=rand_address(), gas_price=rand_range(42857142857143)),
         False,
     ),
+    # Transfer nothing with some calldata
+    (Transaction(caller_address=0xFE, callee_address=0xFF, gas=21080, call_data=bytes([1, 2, 3, 4, 0, 0, 0, 0])), True),
 )
 
 


### PR DESCRIPTION
This PR aims to change the transaction format to legacy one, and defer support of dynamic gas price transaction introduced by `EIP1559` to the future work for simplicity.

It also does:

- Extend `add_word` to `add_words` to match current circuit implementation
- Add `CallDataGasCost` in `tx_table` for lookup to calculate the correct intrinsic gas cost for legacy tx