### PR TITLE
SLOAD/SSTORE opcodes

### DIFF
--- a/specs/opcode/54SLOAD_55SSTORE.md
+++ b/specs/opcode/54SLOAD_55SSTORE.md
@@ -1,0 +1,151 @@
+# SLOAD & SSTORE
+
+## Procedure
+
+### EVM behavior
+
+Storage is a key-value map where both the key and the values are words of 32
+bytes.
+
+The `SLOAD` opcode loads a word (32 bytes of data) from storage into the stack.
+This is done by popping the `key` from the stack, and the value at
+`STORAGE[key]` is then pushed onto the stack.
+
+The `SSTORE` opcode writes a word (32 bytes of data) from the stack into
+storage.  This is done by popping the `key` from the top and the `value` from
+the second position of the stack, and then writing `STORAGE[key] = value`.
+
+### Access Sets
+
+As per [EIP-2929](https://eips.ethereum.org/EIPS/eip-2929), these two opcodes
+update the `Touched Storage Slots` set with the address of the current execution
+context and the accessed key as:
+
+```
+touched_storage_slots = touched_storage_slots ∪ { (context_address, target_storage_key) }
+```
+
+### Gas Costs and Refunds
+
+Computing the gas costs for these opcodes requires knowing whether the slot
+`(context_address, key)` has been touched during the current transaction using
+the `Touched Storage Slots` set.  In case of an `SSTORE`, we also need to know
+the current and original values of that key, where the original value is the
+value in that key at the beginning of the transaction.
+
+The [Yellow Paper](https://ethereum.github.io/yellowpaper/paper.pdf) defines the gas costs for these two opcodes as follows:
+
+#### SLOAD 
+
+- `G_warmaccess`, if the slot has been touched
+- `G_coldsload`, otherwise
+
+#### SSTORE
+
+Let `v0` be the original value of the storage slot.
+Let `v` be the current value.
+Let `v'` be the new value.
+
+`base_gas =`
+- `0`, if the slot has been touched
+- `G_coldsload`, otherwise
+
+`extra_gas =`
+- `G_warmaccess`, if `v = v' or v0 != v`
+- `G_sset`, if `v != v' and v0 = v and v0 = 0`
+- `G_sreset`, if `v != v' and v0 = v and v0 != 0`
+
+The spent gas is `base_gas + extra_gas`.
+
+`refund =`
+- `R_sclear`, if `v0 != 0 and v = 0`
+- `r_dirtyclear` + `r_dirtyreset`, if `v0 != 0 and v' = 0`
+- `0`, otherwise
+
+The refunded gas is `refund`.
+
+where
+
+`r_dirtyclear =`
+- `-R_sclear`, if `v0 != 0 and v = 0`
+- `R_sclear`, if `v0 != 0 and v' = 0`
+- `0`, otherwise
+
+`r_dirtyreset =`
+- `G_sset - G_warmaccess`, if `v0 = v' and v0 = 0`
+- `G_sreset - G_warmaccess`, if `v0 = v' and v0 != 0`
+- `0`, otherwise
+
+```
+G_warmaccess = 100
+G_coldsload = 2100
+G_sset = 20000
+G_sreset = 2900
+R_sclear = 15000
+```
+
+### Circuit behavior
+
+The `StorageGadget` takes arguments
+
+- `opcode: u8`
+- `key: [u8;32]`
+- `new_value: [u8;32]`
+- `original_value: [u8;32]`
+- `current_value: [u8;32]`
+- `is_storage_slot_touched: bool`
+
+There is a check if `opcode` is `SLOAD` or `SSTORE`, which is used to change
+some operations so the correct logic for each opcode is done.
+
+The `storage_slot_touched` Access Set is necessary in order to compute the gas
+and refund amounts using the procedure above, extracted from the Yellow Paper.
+
+For the stack busmapping lookups, the top value is always the `key`. Then,
+depending on the opcode:
+
+- `SLOAD`: `new_value` is pushed on top of the stack (`stack_offset == 0; is_write == true`)
+- `SSTORE`: `new_value` is popped from the top of the stack (`stack_offset == 1; is_write == false`)
+
+For `SLOAD`/`SSTORE` 1 storage busmapping lookup is used to access the storage
+at `[key]` using the byte values of `value`:
+
+- `SLOAD`: the lookup is a read op (`is_write == false`)
+- `SSTORE`: the lookup is a write op (`is_write == true`)
+
+## Constraints
+
+1. opcodeId checks
+   1. opId == OpcodeId(0x54) for `SLOAD`
+   2. opId == OpcodeId(0x55) for `SSTORE`
+2. state transition:
+   - gc
+     - `SLOAD`/`SSTORE`: +3 (2 stack operations + 1 storage read/write)
+   - stack_pointer
+     - `SLOAD`: remains the same
+     - `SSTORE`: -2
+   - pc + 1
+   - gas + `gas_cost` - `refund`
+3. lookups:
+   - `SLOAD`/`SSTORE`: 1 busmapping lookup
+     - stack:
+       - `key` is popped off the top of the stack
+       - `value`
+         - is pushed on top of the stack for `SLOAD`
+         - is popped off the top of the stack for `SSTORE`
+     - storage:
+       - `SLOAD`/`SSTORE`: The 32 bytes of `value` are read/written from/to storage at `key`.
+   - ?? fixed lookups
+
+## Exceptions
+
+1. stack underflow:
+   - the stack is empty: `1024 == stack_pointer`
+   - only for `SSTORE`: the stack contains a single value: `1023 == stack_pointer`
+2. out of gas:
+   - insufficient gas for read/write
+
+## Code
+
+Please refer to `src/zkevm-specs/opcode/sload_sstore.py`.
+ 

--- a/src/zkevm_specs/opcode/sload_sstore.py
+++ b/src/zkevm_specs/opcode/sload_sstore.py
@@ -1,0 +1,97 @@
+from typing import Sequence, Tuple
+from zkevm_specs.opcode.storage import Storage
+from zkevm_specs.opcode.stack import Stack
+from ..encoding import U8, U128, U256, is_circuit_code, u8s_to_u256
+
+OP_SLOAD = 0x54
+OP_SSTORE = 0x55
+
+G_WARM_ACCESS = 100
+G_COLD_SLOAD = 2100
+G_S_SET = 20000
+G_S_RESET = 2900
+
+R_S_CLEAR = 15000
+
+"""
+The Yellow Paper defines:
+We remind the reader that the checkpoint ("original") state sigma_0 is the
+state if the current transaction were to revert.
+Therefore to compute the required gas for an SSTORE we need both the current
+storage and the original storage from the beginning of the transaction.
+"""
+
+
+@is_circuit_code
+def check_storage_ops(
+    opcode: U8,
+    storage: Storage,
+    key8s: Sequence[U8],
+    new_value8s: Sequence[U8],
+    original_value8s: Sequence[U8],
+    current_value8s: Sequence[U8],
+    is_touched: bool,
+    expected_storage_cost: U128,
+    expected_storage_refund: U128,
+):
+    assert len(key8s) == len(new_value8s) == 32
+
+    # Check if this is an SLOAD or SSTORE
+    is_sload = opcode == OP_SLOAD
+    is_sstore = opcode == OP_SSTORE
+
+    assert is_sload or is_sstore
+
+    key = u8s_to_u256(key8s)
+    new_value = u8s_to_u256(new_value8s)
+    original_value = u8s_to_u256(original_value8s)
+    current_value = u8s_to_u256(current_value8s)
+
+    if is_sload:
+        assert storage.read(key) == new_value
+    else:
+        assert storage.read(key) == current_value
+        storage.write(key, new_value)
+
+    gas_cost = 0
+    gas_refund = 0
+
+    if is_sload:
+        if is_touched:  # warm access
+            gas_cost = G_WARM_ACCESS
+        else:  # cold access
+            gas_cost = G_COLD_SLOAD
+    else:
+        # gas
+        if not is_touched:  # cold access
+            gas_cost = G_COLD_SLOAD
+
+        if current_value == new_value or original_value != current_value:
+            gas_cost += G_WARM_ACCESS
+        elif current_value != new_value and original_value == current_value and original_value == 0:
+            gas_cost += G_S_SET
+        elif current_value != new_value and original_value == current_value and original_value != 0:
+            gas_cost += G_S_RESET
+
+        # refund
+        if current_value != new_value and original_value == current_value and new_value == 0:
+            gas_refund = R_S_CLEAR
+        elif current_value != new_value and original_value != current_value:
+            r_dirty_clear = 0
+            if original_value != 0 and current_value == 0:
+                r_dirty_clear = -R_S_CLEAR
+            elif original_value != 0 and new_value == 0:
+                r_dirty_clear = R_S_CLEAR
+
+            r_dirty_reset = 0
+            if original_value == new_value and original_value == 0:
+                r_dirty_reset = G_S_SET - G_WARM_ACCESS
+            elif original_value == new_value and original_value != 0:
+                r_dirty_reset = G_S_RESET - G_WARM_ACCESS
+
+            gas_refund = r_dirty_clear + r_dirty_reset
+        else:
+            gas_refund = 0
+
+    assert expected_storage_cost == gas_cost
+    assert expected_storage_refund == gas_refund

--- a/src/zkevm_specs/opcode/storage.py
+++ b/src/zkevm_specs/opcode/storage.py
@@ -1,0 +1,27 @@
+# Simulate an Ethereum contract's storage.
+# The storage consists of a key-value map where
+# both the key and the value are 256 bit numbers.
+
+
+class Storage:
+    def __init__(self):
+        self.data = {}
+
+    def has_key(self, key):
+        return key in self.data
+
+    def read(self, key):
+        if self.has_key(key):
+            return self.data[key]
+        return 0
+
+    def write(self, key, value):
+        assert 0 <= key and key < 2 ** 256
+        assert 0 <= value and value < 2 ** 256
+        self.data[key] = value
+
+    def op(self, key, value, is_write):
+        if is_write:
+            self.write(key, value)
+        else:
+            assert self.read(key) == value

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,11 @@
+from zkevm_specs.encoding import u256_to_u8s
+from zkevm_specs.opcode.storage import Storage
+from zkevm_specs.opcode.sload_sstore import *
+
+
+def test_check_storage_ops():
+    storage = Storage()
+    z8s = u256_to_u8s(0)
+
+    # Load a value from key 0.
+    check_storage_ops(OP_SLOAD, storage, z8s, z8s, z8s, z8s, False, G_COLD_SLOAD, 0)


### PR DESCRIPTION
@barryWhiteHat suggested I worked on this, so here's my attempt. I used the MLOAD/MSTORE specs as base, and I'm not sure about several things in this spec cus I don't know a lot about that stuff in general, especially in the circuit and constraints sections.

I'll start working on the Rust zkevm-circuit side of this once this spec is stable.

Here are my questions for this spec:

- Does the Access Set need to be taken into account somehow? Both SLOAD and STORE read from the set and potentially update it with the pair `(context_address, key)`. Currently I just used a Boolean flag `is_touched`, which I guess would somehow come from the busmapping? Would we need two versions of that flag here, one pre and one post update?
- For the gas computation we need to know the storage[key] value at the beginning of the transaction and the current one. Would both also just come from the busmapping?
- In the constraints part, for memory 32 lookups were needed, one for each byte. I wrote 1 lookup here because storage slots are always 32 bytes, but does that mean we also need 32 lookups here?

Happy to get any direction on those items and fix them!