### PR TITLE
Spec `ExecutionState::{EndTx,EndBlock}`

### DIFF
--- a/src/zkevm_specs/evm/execution/__init__.py
+++ b/src/zkevm_specs/evm/execution/__init__.py
@@ -3,6 +3,8 @@ from typing import Callable, Dict
 from ..execution_state import ExecutionState
 
 from .begin_tx import *
+from .end_tx import *
+from .end_block import *
 
 # Opcode's successful cases
 from .add import *
@@ -15,6 +17,8 @@ from .caller import *
 
 EXECUTION_STATE_IMPL: Dict[ExecutionState, Callable] = {
     ExecutionState.BeginTx: begin_tx,
+    ExecutionState.EndTx: end_tx,
+    ExecutionState.EndBlock: end_block,
     ExecutionState.ADD: add,
     ExecutionState.CALLER: caller,
     ExecutionState.COINBASE: coinbase,

--- a/src/zkevm_specs/evm/execution/__init__.py
+++ b/src/zkevm_specs/evm/execution/__init__.py
@@ -1,11 +1,24 @@
+from typing import Callable, Dict
+
+from ..execution_state import ExecutionState
+
 from .begin_tx import *
 
 # Opcode's successful cases
 from .add import *
-from .push import *
 from .jump import *
 from .jumpi import *
+from .push import *
 from .block_coinbase import *
 from .caller import *
 
-# Error cases
+
+EXECUTION_STATE_IMPL: Dict[ExecutionState, Callable] = {
+    ExecutionState.BeginTx: begin_tx,
+    ExecutionState.ADD: add,
+    ExecutionState.CALLER: caller,
+    ExecutionState.COINBASE: coinbase,
+    ExecutionState.JUMP: jump,
+    ExecutionState.JUMPI: jumpi,
+    ExecutionState.PUSH: push,
+}

--- a/src/zkevm_specs/evm/execution/add.py
+++ b/src/zkevm_specs/evm/execution/add.py
@@ -16,7 +16,7 @@ def add(instruction: Instruction):
         instruction.select(is_sub, a, c),
     )
 
-    instruction.constrain_same_context_state_transition(
+    instruction.step_state_transition_in_same_context(
         opcode,
         rw_counter=Transition.delta(3),
         program_counter=Transition.delta(1),

--- a/src/zkevm_specs/evm/execution/begin_tx.py
+++ b/src/zkevm_specs/evm/execution/begin_tx.py
@@ -1,41 +1,44 @@
+from ...util import GAS_COST_TX, GAS_COST_CREATION_TX
 from ..instruction import Instruction, Transition
-from ..table import CallContextFieldTag, TxContextFieldTag, RW, AccountFieldTag
+from ..table import CallContextFieldTag, TxContextFieldTag, AccountFieldTag
 from ..precompiled import PrecompiledAddress
 
 
-def begin_tx(instruction: Instruction, is_first_step: bool = False):
-    instruction.constrain_equal(instruction.curr.call_id, instruction.curr.rw_counter)
+def begin_tx(instruction: Instruction):
+    call_id = instruction.curr.rw_counter
 
-    tx_id = instruction.call_context_lookup(CallContextFieldTag.TxId)
-    rw_counter_end_of_reversion = instruction.call_context_lookup(CallContextFieldTag.RWCounterEndOfReversion)
-    is_persistent = instruction.call_context_lookup(CallContextFieldTag.IsPersistent)
+    tx_id = instruction.call_context_lookup(CallContextFieldTag.TxId, call_id=call_id)
+    rw_counter_end_of_reversion = instruction.call_context_lookup(
+        CallContextFieldTag.RwCounterEndOfReversion, call_id=call_id
+    )
+    is_persistent = instruction.call_context_lookup(CallContextFieldTag.IsPersistent, call_id=call_id)
 
-    if is_first_step:
+    if instruction.is_first_step:
         instruction.constrain_equal(instruction.curr.rw_counter, 1)
         instruction.constrain_equal(tx_id, 1)
 
-    tx_caller_address = instruction.tx_lookup(tx_id, TxContextFieldTag.CallerAddress)
-    tx_callee_address = instruction.tx_lookup(tx_id, TxContextFieldTag.CalleeAddress)
-    tx_is_create = instruction.tx_lookup(tx_id, TxContextFieldTag.IsCreate)
-    tx_value = instruction.tx_lookup(tx_id, TxContextFieldTag.Value)
-    tx_call_data_length = instruction.tx_lookup(tx_id, TxContextFieldTag.CallDataLength)
+    tx_caller_address = instruction.tx_context_lookup(tx_id, TxContextFieldTag.CallerAddress)
+    tx_callee_address = instruction.tx_context_lookup(tx_id, TxContextFieldTag.CalleeAddress)
+    tx_is_create = instruction.tx_context_lookup(tx_id, TxContextFieldTag.IsCreate)
+    tx_value = instruction.tx_context_lookup(tx_id, TxContextFieldTag.Value)
+    tx_call_data_length = instruction.tx_context_lookup(tx_id, TxContextFieldTag.CallDataLength)
 
     # Verify nonce
-    tx_nonce = instruction.tx_lookup(tx_id, TxContextFieldTag.Nonce)
+    tx_nonce = instruction.tx_context_lookup(tx_id, TxContextFieldTag.Nonce)
     nonce, nonce_prev = instruction.account_write(tx_caller_address, AccountFieldTag.Nonce)
     instruction.constrain_equal(tx_nonce, nonce_prev)
     instruction.constrain_equal(nonce, nonce_prev + 1)
 
     # TODO: Implement EIP 1559 (currently it supports legacy transaction format)
     # Calculate gas fee
-    tx_gas = instruction.tx_lookup(tx_id, TxContextFieldTag.Gas)
-    tx_gas_price = instruction.tx_lookup(tx_id, TxContextFieldTag.GasPrice)
+    tx_gas = instruction.tx_context_lookup(tx_id, TxContextFieldTag.Gas)
+    tx_gas_price = instruction.tx_gas_price(tx_id)
     gas_fee, carry = instruction.mul_word_by_u64(tx_gas_price, tx_gas)
     instruction.constrain_zero(carry)
 
     # TODO: Handle gas cost of tx level access list (EIP 2930)
-    tx_call_data_gas_cost = instruction.tx_lookup(tx_id, TxContextFieldTag.CallDataGasCost)
-    gas_left = tx_gas - (53000 if tx_is_create else 21000) - tx_call_data_gas_cost
+    tx_call_data_gas_cost = instruction.tx_context_lookup(tx_id, TxContextFieldTag.CallDataGasCost)
+    gas_left = tx_gas - (GAS_COST_CREATION_TX if tx_is_create else GAS_COST_TX) - tx_call_data_gas_cost
     instruction.constrain_gas_left_not_underflow(gas_left)
 
     # Prepare access list of caller and callee
@@ -47,27 +50,27 @@ def begin_tx(instruction: Instruction, is_first_step: bool = False):
         tx_caller_address,
         tx_callee_address,
         tx_value,
-        gas_fee=gas_fee,
-        is_persistent=is_persistent,
-        rw_counter_end_of_reversion=rw_counter_end_of_reversion,
+        gas_fee,
+        is_persistent,
+        rw_counter_end_of_reversion,
     )
 
     if tx_is_create:
         # TODO: Verify receiver address
-        # TODO: Set opcode_source to tx_id
+        # TODO: Decide what code_source should be (tx_id or hash of creation code)
         raise NotImplementedError
     elif tx_callee_address in list(PrecompiledAddress):
         # TODO: Handle precompile
         raise NotImplementedError
     else:
-        code_hash, _ = instruction.account_read(tx_callee_address, AccountFieldTag.CodeHash)
+        code_hash = instruction.account_read(tx_callee_address, AccountFieldTag.CodeHash)
 
         # Setup next call's context
         # Note that:
-        # - CallerCallId, ReturnDataOffset, ReturnDataLength, Result
-        #   should never be used in root call, so unnecessary to check
-        # - TxId is propagated from previous step or constraint to 1 if is_first_step
-        # - IsPersistent will be verified in the end of tx
+        # - CallerId, ReturnDataOffset, ReturnDataLength
+        #   should never be used in root call, so unnecessary to be checked
+        # - TxId is checked from previous step or constraint to 1 if is_first_step
+        # - IsSuccess, IsPersistent will be verified in the end of tx
         for (tag, value) in [
             (CallContextFieldTag.Depth, 1),
             (CallContextFieldTag.CallerAddress, tx_caller_address),
@@ -77,14 +80,14 @@ def begin_tx(instruction: Instruction, is_first_step: bool = False):
             (CallContextFieldTag.Value, tx_value),
             (CallContextFieldTag.IsStatic, False),
         ]:
-            instruction.constrain_equal(instruction.call_context_lookup(tag), value)
+            instruction.constrain_equal(instruction.call_context_lookup(tag, call_id=call_id), value)
 
-        instruction.constrain_new_context_state_transition(
+        instruction.step_state_transition_to_new_context(
             rw_counter=Transition.delta(16),
-            call_id=Transition.persistent(),
+            call_id=Transition.to(call_id),
             is_root=Transition.to(True),
             is_create=Transition.to(False),
-            opcode_source=Transition.to(code_hash),
+            code_source=Transition.to(code_hash),
             gas_left=Transition.to(gas_left),
             state_write_counter=Transition.to(2),
         )

--- a/src/zkevm_specs/evm/execution/block_coinbase.py
+++ b/src/zkevm_specs/evm/execution/block_coinbase.py
@@ -11,10 +11,15 @@ def coinbase(instruction: Instruction):
     # check block table for coinbase address
     instruction.constrain_equal(
         address,
-        instruction.bytes_to_rlc(instruction.int_to_bytes(instruction.block_lookup(BlockContextFieldTag.Coinbase), 20)),
+        instruction.bytes_to_rlc(
+            instruction.int_to_bytes(
+                instruction.block_context_lookup(BlockContextFieldTag.Coinbase),
+                20,
+            )
+        ),
     )
 
-    instruction.constrain_same_context_state_transition(
+    instruction.step_state_transition_in_same_context(
         opcode,
         rw_counter=Transition.delta(1),
         program_counter=Transition.delta(1),

--- a/src/zkevm_specs/evm/execution/block_coinbase.py
+++ b/src/zkevm_specs/evm/execution/block_coinbase.py
@@ -11,11 +11,9 @@ def coinbase(instruction: Instruction):
     # check block table for coinbase address
     instruction.constrain_equal(
         address,
-        instruction.bytes_to_rlc(
-            instruction.int_to_bytes(
-                instruction.block_context_lookup(BlockContextFieldTag.Coinbase),
-                20,
-            )
+        instruction.int_to_rlc(
+            instruction.block_context_lookup(BlockContextFieldTag.Coinbase),
+            20,
         ),
     )
 

--- a/src/zkevm_specs/evm/execution/caller.py
+++ b/src/zkevm_specs/evm/execution/caller.py
@@ -19,7 +19,7 @@ def caller(instruction: Instruction):
         ),
     )
 
-    instruction.constrain_same_context_state_transition(
+    instruction.step_state_transition_in_same_context(
         opcode,
         rw_counter=Transition.delta(2),
         program_counter=Transition.delta(1),

--- a/src/zkevm_specs/evm/execution/caller.py
+++ b/src/zkevm_specs/evm/execution/caller.py
@@ -11,11 +11,9 @@ def caller(instruction: Instruction):
     # check [rw_table, call_context] table for caller address
     instruction.constrain_equal(
         address,
-        instruction.bytes_to_rlc(
-            instruction.int_to_bytes(
-                instruction.call_context_lookup(CallContextFieldTag.CallerAddress),
-                20,
-            )
+        instruction.int_to_rlc(
+            instruction.call_context_lookup(CallContextFieldTag.CallerAddress),
+            20,
         ),
     )
 

--- a/src/zkevm_specs/evm/execution/end_block.py
+++ b/src/zkevm_specs/evm/execution/end_block.py
@@ -1,0 +1,30 @@
+from ..instruction import Instruction, Transition
+from ..table import CallContextFieldTag
+
+
+# TODO: Introduce constrain_instance to constrain the equality between witness
+#       and public input, for total_tx and total_rw
+
+
+def end_block(instruction: Instruction):
+    if instruction.is_last_step:
+        # Verify final step has tx_id identical to the tx amount in tx_table.
+        total_tx = instruction.call_context_lookup(CallContextFieldTag.TxId)
+        instruction.constrain_equal(
+            total_tx,
+            max([tx_id for tx_id, *_ in instruction.tables.tx_table]),
+        )
+
+        # Verify rw_counter counts to identical rw amount in rw_table to ensure
+        # there is no malicious insertion.
+        total_rw = instruction.curr.rw_counter + 1  # extra 1 from the tx_id lookup
+        instruction.constrain_equal(
+            total_rw,
+            len(instruction.tables.rw_table),
+        )
+    else:
+        # Propagate rw_counter and call_id all the way down
+        instruction.constrain_step_state_transition(
+            rw_counter=Transition.same(),
+            call_id=Transition.same(),
+        )

--- a/src/zkevm_specs/evm/execution/end_tx.py
+++ b/src/zkevm_specs/evm/execution/end_tx.py
@@ -1,0 +1,43 @@
+from ...util import N_BYTES_GAS
+from ..execution_state import ExecutionState
+from ..instruction import Instruction
+from ..table import BlockContextFieldTag, CallContextFieldTag, TxContextFieldTag
+
+
+def end_tx(instruction: Instruction):
+    tx_id = instruction.call_context_lookup(CallContextFieldTag.TxId)
+
+    # Handle gas refund (refund is capped to gas_used // 2 in EIP 3529)
+    tx_gas = instruction.tx_context_lookup(tx_id, TxContextFieldTag.Gas)
+    gas_used = tx_gas - instruction.curr.gas_left
+    capped_refund, _ = instruction.constant_divmod(gas_used, 2, N_BYTES_GAS)
+    accumulated_refund = instruction.tx_refund_read(tx_id)
+    refund = instruction.min(capped_refund, accumulated_refund, 8)
+
+    # Add refund * gas_price back to caller's balance
+    tx_gas_price = instruction.tx_gas_price(tx_id)
+    value, carry = instruction.mul_word_by_u64(tx_gas_price, refund)
+    instruction.constrain_zero(carry)
+    tx_caller_address = instruction.tx_context_lookup(tx_id, TxContextFieldTag.CallerAddress)
+    instruction.add_balance(tx_caller_address, [value])
+
+    # Add gas_used * effective_tip to coinbase's balance
+    base_fee = instruction.block_context_lookup(BlockContextFieldTag.BaseFee)
+    effective_tip, _ = instruction.sub_word(tx_gas_price, base_fee)
+    reward, carry = instruction.mul_word_by_u64(effective_tip, gas_used)
+    instruction.constrain_zero(carry)
+    coinbase = instruction.block_context_lookup(BlockContextFieldTag.Coinbase)
+    instruction.add_balance(coinbase, [reward])
+
+    # Do step state transition for rw_counter
+    instruction.constrain_equal(instruction.next.rw_counter, instruction.curr.rw_counter + 7)
+
+    # Go to next transaction
+    if instruction.next.execution_state == ExecutionState.BeginTx:
+        # Check next tx_id is increased by 1
+        instruction.constrain_equal(
+            instruction.call_context_lookup(CallContextFieldTag.TxId, call_id=instruction.next.rw_counter),
+            tx_id + 1,
+        )
+
+    # Or to ExecutionState.EndBlock

--- a/src/zkevm_specs/evm/execution/end_tx.py
+++ b/src/zkevm_specs/evm/execution/end_tx.py
@@ -1,22 +1,22 @@
-from ...util import N_BYTES_GAS
+from ...util import N_BYTES_GAS, MAX_REFUND_QUOTIENT_OF_GAS_USED
 from ..execution_state import ExecutionState
-from ..instruction import Instruction
+from ..instruction import Instruction, Transition
 from ..table import BlockContextFieldTag, CallContextFieldTag, TxContextFieldTag
 
 
 def end_tx(instruction: Instruction):
     tx_id = instruction.call_context_lookup(CallContextFieldTag.TxId)
 
-    # Handle gas refund (refund is capped to gas_used // 2 in EIP 3529)
+    # Handle gas refund (refund is capped to gas_used // MAX_REFUND_QUOTIENT_OF_GAS_USED in EIP 3529)
     tx_gas = instruction.tx_context_lookup(tx_id, TxContextFieldTag.Gas)
     gas_used = tx_gas - instruction.curr.gas_left
-    capped_refund, _ = instruction.constant_divmod(gas_used, 2, N_BYTES_GAS)
-    accumulated_refund = instruction.tx_refund_read(tx_id)
-    refund = instruction.min(capped_refund, accumulated_refund, 8)
+    max_refund, _ = instruction.constant_divmod(gas_used, MAX_REFUND_QUOTIENT_OF_GAS_USED, N_BYTES_GAS)
+    refund = instruction.tx_refund_read(tx_id)
+    effective_refund = instruction.min(max_refund, refund, 8)
 
-    # Add refund * gas_price back to caller's balance
+    # Add effective_refund * gas_price back to caller's balance
     tx_gas_price = instruction.tx_gas_price(tx_id)
-    value, carry = instruction.mul_word_by_u64(tx_gas_price, refund)
+    value, carry = instruction.mul_word_by_u64(tx_gas_price, instruction.curr.gas_left + effective_refund)
     instruction.constrain_zero(carry)
     tx_caller_address = instruction.tx_context_lookup(tx_id, TxContextFieldTag.CallerAddress)
     instruction.add_balance(tx_caller_address, [value])
@@ -29,9 +29,6 @@ def end_tx(instruction: Instruction):
     coinbase = instruction.block_context_lookup(BlockContextFieldTag.Coinbase)
     instruction.add_balance(coinbase, [reward])
 
-    # Do step state transition for rw_counter
-    instruction.constrain_equal(instruction.next.rw_counter, instruction.curr.rw_counter + 7)
-
     # Go to next transaction
     if instruction.next.execution_state == ExecutionState.BeginTx:
         # Check next tx_id is increased by 1
@@ -40,4 +37,11 @@ def end_tx(instruction: Instruction):
             tx_id + 1,
         )
 
-    # Or to ExecutionState.EndBlock
+        # Do step state transition for rw_counter
+        instruction.constrain_step_state_transition(rw_counter=Transition.delta(5))
+    # Go to end of block
+    elif instruction.next.execution_state == ExecutionState.EndBlock:
+        # Do step state transition for rw_counter
+        instruction.constrain_step_state_transition(rw_counter=Transition.delta(4))
+    else:
+        raise ValueError("Unreacheable")

--- a/src/zkevm_specs/evm/execution/jump.py
+++ b/src/zkevm_specs/evm/execution/jump.py
@@ -1,3 +1,4 @@
+from ...util.param import N_BYTES_PROGRAM_COUNTER
 from ..instruction import Instruction, Transition
 from ..opcode import Opcode
 
@@ -11,13 +12,13 @@ def jump(instruction: Instruction):
     dest = instruction.stack_pop()
 
     # Get `dest` raw value in max 8 bytes
-    dest_value = instruction.bytes_to_int(instruction.rlc_to_bytes(dest, 8))
+    dest_value = instruction.rlc_to_int_exact(dest, N_BYTES_PROGRAM_COUNTER)
 
     # Verify `dest` is code within byte code table
     # assert Opcode.JUMPDEST == instruction.opcode_lookup_at(dest_value, True)
     instruction.constrain_equal(Opcode.JUMPDEST, instruction.opcode_lookup_at(dest_value, True))
 
-    instruction.constrain_same_context_state_transition(
+    instruction.step_state_transition_in_same_context(
         opcode,
         rw_counter=Transition.delta(1),
         program_counter=Transition.to(dest_value),

--- a/src/zkevm_specs/evm/execution/jumpi.py
+++ b/src/zkevm_specs/evm/execution/jumpi.py
@@ -1,3 +1,4 @@
+from ...util.param import N_BYTES_PROGRAM_COUNTER
 from ..instruction import Instruction, Transition
 from ..opcode import Opcode
 
@@ -16,12 +17,12 @@ def jumpi(instruction: Instruction):
         pc_diff = 1
     else:
         # Get `dest` raw value in max 8 bytes
-        dest_value = instruction.bytes_to_int(instruction.rlc_to_bytes(dest, 8))
+        dest_value = instruction.rlc_to_int_exact(dest, N_BYTES_PROGRAM_COUNTER)
         pc_diff = dest_value - instruction.curr.program_counter
         # assert Opcode.JUMPDEST == instruction.opcode_lookup_at(dest_value, True)
         instruction.constrain_equal(Opcode.JUMPDEST, instruction.opcode_lookup_at(dest_value, True))
 
-    instruction.constrain_same_context_state_transition(
+    instruction.step_state_transition_in_same_context(
         opcode,
         rw_counter=Transition.delta(2),
         program_counter=Transition.delta(pc_diff),

--- a/src/zkevm_specs/evm/execution/push.py
+++ b/src/zkevm_specs/evm/execution/push.py
@@ -8,17 +8,17 @@ def push(instruction: Instruction):
     num_additional_pushed = num_pushed - 1
 
     value = instruction.stack_push()
-    value_bytes = instruction.rlc_to_bytes(value, 32)
+    value_le_bytes = instruction.rlc_to_le_bytes(value)
     selectors = instruction.continuous_selectors(num_additional_pushed, 31)
 
     for idx in range(32):
         index = instruction.curr.program_counter + num_pushed - idx
         if idx == 0 or selectors[idx - 1]:
-            instruction.constrain_equal(value_bytes[idx], instruction.opcode_lookup_at(index, False))
+            instruction.constrain_equal(value_le_bytes[idx], instruction.opcode_lookup_at(index, False))
         else:
-            instruction.constrain_zero(value_bytes[idx])
+            instruction.constrain_zero(value_le_bytes[idx])
 
-    instruction.constrain_same_context_state_transition(
+    instruction.step_state_transition_in_same_context(
         opcode,
         rw_counter=Transition.delta(1),
         program_counter=Transition.delta(1 + num_pushed),

--- a/src/zkevm_specs/evm/execution_state.py
+++ b/src/zkevm_specs/evm/execution_state.py
@@ -10,6 +10,8 @@ class ExecutionState(IntEnum):
     """
 
     BeginTx = auto()
+    EndTx = auto()
+    EndBlock = auto()
 
     # Opcode's successful cases
     STOP = auto()

--- a/src/zkevm_specs/evm/instruction.py
+++ b/src/zkevm_specs/evm/instruction.py
@@ -2,7 +2,17 @@ from __future__ import annotations
 from enum import IntEnum, auto
 from typing import Optional, Sequence, Tuple, Union
 
-from ..util import Array4, Array8, linear_combine, RLCStore, MAX_N_BYTES, N_BYTES_GAS
+from ..util import (
+    Array4,
+    Array8,
+    RLC,
+    MAX_N_BYTES,
+    N_BYTES_MEMORY_ADDRESS,
+    N_BYTES_MEMORY_SIZE,
+    N_BYTES_GAS,
+    MEMORY_EXPANSION_QUAD_DENOMINATOR,
+    MEMORY_EXPANSION_LINEAR_COEFF,
+)
 from .opcode import Opcode
 from .step import StepState
 from .table import (
@@ -23,7 +33,7 @@ class ConstraintUnsatFailure(Exception):
 
 
 class TransitionKind(IntEnum):
-    Persistent = auto()
+    Same = auto()
     Delta = auto()
     To = auto()
 
@@ -36,8 +46,8 @@ class Transition:
         self.kind = kind
         self.value = value
 
-    def persistent() -> Transition:
-        return Transition(TransitionKind.Persistent)
+    def same() -> Transition:
+        return Transition(TransitionKind.Same)
 
     def delta(delta: int):
         return Transition(TransitionKind.Delta, delta)
@@ -47,85 +57,104 @@ class Transition:
 
 
 class Instruction:
-    rlc_store: RLCStore
+    randomness: int
     tables: Tables
     curr: StepState
     next: StepState
 
+    # meta information
+    is_first_step: bool
+    is_last_step: bool
+
     # helper numbers
-    cell_offset: int = 0
     rw_counter_offset: int = 0
     program_counter_offset: int = 0
     stack_pointer_offset: int = 0
     state_write_counter_offset: int = 0
 
-    def __init__(self, rlc_store: RLCStore, tables: Tables, curr: StepState, next: StepState) -> None:
-        self.rlc_store = rlc_store
+    def __init__(
+        self,
+        randomness: int,
+        tables: Tables,
+        curr: StepState,
+        next: StepState,
+        is_first_step: bool,
+        is_last_step: bool,
+    ) -> None:
+        self.randomness = randomness
         self.tables = tables
         self.curr = curr
         self.next = next
+        self.is_first_step = is_first_step
+        self.is_last_step = is_last_step
 
     def constrain_zero(self, value: int):
-        assert value == 0
+        assert value == 0, ConstraintUnsatFailure(f"Expected value to be 0, but got {value}")
 
     def constrain_equal(self, lhs: int, rhs: int):
-        self.constrain_zero(lhs - rhs)
+        assert lhs == rhs, ConstraintUnsatFailure(f"Expected values to be equal, but got {lhs} and {rhs}")
 
     def constrain_bool(self, value: int):
-        assert value in [0, 1]
+        assert value in [0, 1], ConstraintUnsatFailure(f"Expected value to be a bool, but got {value}")
 
     def constrain_gas_left_not_underflow(self, gas_left: int):
         self.int_to_bytes(gas_left, N_BYTES_GAS)
 
-    def constrain_state_transition(self, **kwargs: Transition):
-        for key in [
-            "rw_counter",
-            "call_id",
-            "is_root",
-            "is_create",
-            "opcode_source",
-            "program_counter",
-            "stack_pointer",
-            "gas_left",
-            "memory_size",
-            "state_write_counter",
-            "last_callee_id",
-            "last_callee_return_data_offset",
-            "last_callee_return_data_length",
-        ]:
+    def constrain_step_state_transition(self, **kwargs: Transition):
+        keys = set(
+            [
+                "rw_counter",
+                "call_id",
+                "is_root",
+                "is_create",
+                "code_source",
+                "program_counter",
+                "stack_pointer",
+                "gas_left",
+                "memory_size",
+                "state_write_counter",
+                "last_callee_id",
+                "last_callee_return_data_offset",
+                "last_callee_return_data_length",
+            ]
+        )
+
+        assert keys.issuperset(
+            kwargs.keys()
+        ), f"Invalid keys {list(set(kwargs.keys()).difference(keys))} for step state transition"
+
+        for key in keys:
             curr, next = getattr(self.curr, key), getattr(self.next, key)
-            transition = kwargs.get(key, Transition.persistent())
-            if transition.kind == TransitionKind.Persistent:
-                assert next == curr, ConstraintUnsatFailure(
-                    f"state {key} should be persistent as {curr}, but got {next}"
-                )
+            transition = kwargs.get(key, Transition.same())
+            if transition.kind == TransitionKind.Same:
+                assert next == curr, ConstraintUnsatFailure(f"State {key} should be same as {curr}, but got {next}")
             elif transition.kind == TransitionKind.Delta:
                 assert next == curr + transition.value, ConstraintUnsatFailure(
-                    f"state {key} should transit to ${curr + transition.value}, but got {next}"
+                    f"State {key} should transit to {curr + transition.value}, but got {next}"
                 )
             elif transition.kind == TransitionKind.To:
                 assert next == transition.value, ConstraintUnsatFailure(
-                    f"state {key} should transit to ${transition.value}, but got {next}"
+                    f"State {key} should transit to {transition.value}, but got {next}"
                 )
             else:
                 raise ValueError("unreacheable")
 
-    def constrain_new_context_state_transition(
+    def step_state_transition_to_new_context(
         self,
         rw_counter: Transition,
         call_id: Transition,
         is_root: Transition,
         is_create: Transition,
-        opcode_source: Transition,
+        code_source: Transition,
         gas_left: Transition,
         state_write_counter: Transition,
     ):
-        self.constrain_state_transition(
+        self.constrain_step_state_transition(
             rw_counter=rw_counter,
             call_id=call_id,
             is_root=is_root,
             is_create=is_create,
-            opcode_source=opcode_source,
+            code_source=code_source,
             gas_left=gas_left,
             state_write_counter=state_write_counter,
             # Initailization unconditionally
@@ -137,19 +166,21 @@ class Instruction:
             last_callee_return_data_length=Transition.to(0),
         )
 
-    def constrain_same_context_state_transition(
+    def step_state_transition_in_same_context(
         self,
         opcode: int,
-        rw_counter: Transition = Transition.persistent(),
-        program_counter: Transition = Transition.persistent(),
-        stack_pointer: Transition = Transition.persistent(),
-        memory_size: Transition = Transition.persistent(),
+        rw_counter: Transition = Transition.same(),
+        program_counter: Transition = Transition.same(),
+        stack_pointer: Transition = Transition.same(),
+        memory_size: Transition = Transition.same(),
         dynamic_gas_cost: int = 0,
     ):
-        gas_cost = Opcode(opcode).constant_gas_cost() + dynamic_gas_cost
+        self.responsible_opcode_lookup(opcode)
 
+        gas_cost = Opcode(opcode).constant_gas_cost() + dynamic_gas_cost
         self.constrain_gas_left_not_underflow(self.curr.gas_left - gas_cost)
-        self.constrain_state_transition(
+
+        self.constrain_step_state_transition(
             rw_counter=rw_counter,
             program_counter=program_counter,
             stack_pointer=stack_pointer,
@@ -157,10 +188,19 @@ class Instruction:
             gas_left=Transition.delta(-gas_cost),
         )
 
-    def is_zero(self, value: int) -> bool:
+    def sum(self, values: Sequence[int]) -> int:
+        return sum(values)
+
+    def is_zero(self, value: Union[int, RLC]) -> bool:
+        if isinstance(value, RLC):
+            value = value.value
         return value == 0
 
-    def is_equal(self, lhs: int, rhs: int) -> bool:
+    def is_equal(self, lhs: Union[int, RLC], rhs: Union[int, RLC]) -> bool:
+        if isinstance(lhs, RLC):
+            lhs = lhs.value
+        if isinstance(rhs, RLC):
+            rhs = rhs.value
         return self.is_zero(lhs - rhs)
 
     def continuous_selectors(self, t: int, n: int) -> Sequence[int]:
@@ -172,22 +212,38 @@ class Instruction:
     def pair_select(self, value: int, lhs: int, rhs: int) -> Tuple[bool, bool]:
         return value == lhs, value == rhs
 
-    def add_words(self, addends: Sequence[int]) -> Tuple[int, int]:
-        def rlc_to_lo_hi(rlc: int) -> Tuple[Sequence[int], Sequence[int]]:
-            bytes = self.rlc_to_bytes(rlc, 32)
-            return self.bytes_to_int(bytes[:16]), self.bytes_to_int(bytes[16:])
+    def constant_divmod(self, numerator: int, denominator: int, n_bytes: int) -> Tuple[int, int]:
+        quotient, remainder = divmod(numerator, denominator)
+        self.int_to_bytes(quotient, n_bytes)
+        return quotient, remainder
 
-        addends_lo, addends_hi = list(zip(*map(rlc_to_lo_hi, addends)))
-        carry_lo, sum_lo = divmod(sum(addends_lo), 1 << 128)
-        carry_hi, sum_hi = divmod(sum(addends_hi) + carry_lo, 1 << 128)
+    def compare(self, lhs: int, rhs: int, n_bytes: int) -> Tuple[bool, bool]:
+        assert n_bytes <= MAX_N_BYTES, "Too many bytes to composite an integer in field"
+
+        return lhs < rhs, lhs == rhs
+
+    def min(self, lhs: int, rhs: int, n_bytes: int) -> int:
+        lt, _ = self.compare(lhs, rhs, n_bytes)
+        return self.select(lt, lhs, rhs)
+
+    def max(self, lhs: int, rhs: int, n_bytes: int) -> int:
+        lt, _ = self.compare(lhs, rhs, n_bytes)
+        return self.select(lt, rhs, lhs)
+
+    def add_words(self, addends: Sequence[RLC]) -> Tuple[RLC, int]:
+        addends_lo, addends_hi = list(zip(*map(self.word_to_lo_hi, addends)))
+
+        carry_lo, sum_lo = divmod(self.sum(addends_lo), 1 << 128)
+        carry_hi, sum_hi = divmod(self.sum(addends_hi) + carry_lo, 1 << 128)
 
         sum_bytes = sum_lo.to_bytes(16, "little") + sum_hi.to_bytes(16, "little")
 
-        return self.rlc_store.to_rlc(sum_bytes), carry_hi
+        return RLC(sum_bytes, self.randomness), carry_hi
 
-    def sub_word(self, minuend: int, subtrahend: int) -> Tuple[int, bool]:
-        minuend_lo, minuend_hi = self.rlc_to_lo_hi(minuend)
-        subtrahend_lo, subtrahend_hi = self.rlc_to_lo_hi(subtrahend)
+    def sub_word(self, minuend: RLC, subtrahend: RLC) -> Tuple[RLC, bool]:
+        minuend_lo, minuend_hi = self.word_to_lo_hi(minuend)
+        subtrahend_lo, subtrahend_hi = self.word_to_lo_hi(subtrahend)
+
         borrow_lo = minuend_lo < subtrahend_lo
         diff_lo = minuend_lo - subtrahend_lo + (1 << 128 if borrow_lo else 0)
         borrow_hi = minuend_hi < subtrahend_hi + borrow_lo
@@ -195,55 +251,80 @@ class Instruction:
 
         diff_bytes = diff_lo.to_bytes(16, "little") + diff_hi.to_bytes(16, "little")
 
-        return self.rlc_store.to_rlc(diff_bytes), borrow_hi
+        return RLC(diff_bytes, self.randomness), borrow_hi
 
-    def mul_word_by_u64(self, multiplicand: int, multiplier: int) -> Tuple[int, int]:
-        multiplicand_bytes = self.rlc_to_bytes(multiplicand, 32)
-
-        multiplicand_lo = self.bytes_to_int(multiplicand_bytes[:16])
-        multiplicand_hi = self.bytes_to_int(multiplicand_bytes[16:])
+    def mul_word_by_u64(self, multiplicand: RLC, multiplier: int) -> Tuple[RLC, int]:
+        multiplicand_lo, multiplicand_hi = self.word_to_lo_hi(multiplicand)
 
         quotient_lo, product_lo = divmod(multiplicand_lo * multiplier, 1 << 128)
         quotient_hi, product_hi = divmod(multiplicand_hi * multiplier + quotient_lo, 1 << 128)
 
         product_bytes = product_lo.to_bytes(16, "little") + product_hi.to_bytes(16, "little")
 
-        return self.rlc_store.to_rlc(product_bytes), quotient_hi
+        return RLC(product_bytes, self.randomness), quotient_hi
 
-    def rlc_to_bytes(self, value: int, n_bytes: int) -> Sequence[int]:
-        bytes = self.rlc_store.to_bytes(value)
-        if len(bytes) > n_bytes and any(bytes[n_bytes:]):
-            raise ConstraintUnsatFailure(f"{value} is too many bytes to fit {n_bytes} bytes")
-        return list(bytes) + (n_bytes - len(bytes)) * [0]
+    def rlc_to_le_bytes(self, rlc: RLC) -> Sequence[int]:
+        return rlc.le_bytes
 
-    def bytes_to_rlc(self, bytes: Sequence[int]) -> int:
-        return self.rlc_store.to_rlc(bytes)
+    def rlc_to_int_unchecked(self, rlc: RLC, n_bytes: int) -> int:
+        rlc_le_bytes = self.rlc_to_le_bytes(rlc)
+        return self.bytes_to_int(rlc_le_bytes[:n_bytes]), self.is_zero(self.sum(rlc_le_bytes[n_bytes:]))
+
+    def rlc_to_int_exact(self, rlc: RLC, n_bytes: int) -> int:
+        rlc_le_bytes = self.rlc_to_le_bytes(rlc)
+
+        if sum(rlc_le_bytes[n_bytes:]) > 0:
+            raise ConstraintUnsatFailure(f"Value {rlc} has too many bytes to fit {n_bytes} bytes")
+
+        return self.bytes_to_int(rlc_le_bytes[:n_bytes])
+
+    def word_to_lo_hi(self, word: RLC) -> Tuple[Sequence[int], Sequence[int]]:
+        word_le_bytes = self.rlc_to_le_bytes(word)
+        assert len(word_le_bytes) == 32, "Expected RLC to contain 32 bytes"
+        return self.bytes_to_int(word_le_bytes[:16]), self.bytes_to_int(word_le_bytes[16:])
+
+    def bytes_to_rlc(self, bytes: Sequence[int]) -> RLC:
+        return RLC(bytes, self.randomness)
 
     def bytes_to_int(self, bytes: Sequence[int]) -> int:
-        assert len(bytes) <= MAX_N_BYTES, "too many bytes to composite an integer in field"
-        return linear_combine(bytes, 256)
+        assert len(bytes) <= MAX_N_BYTES, "Too many bytes to composite an integer in field"
+
+        return int.from_bytes(bytes, "little")
 
     def int_to_bytes(self, value: int, n_bytes: int) -> Sequence[int]:
-        assert n_bytes <= MAX_N_BYTES, "too many bytes to composite an integer in field"
+        assert n_bytes <= MAX_N_BYTES, "Too many bytes to composite an integer in field"
+
         try:
             return value.to_bytes(n_bytes, "little")
         except OverflowError:
-            raise ConstraintUnsatFailure(f"{value} is too many bytes to fit {n_bytes} bytes")
+            raise ConstraintUnsatFailure(f"Value {value} has too many bytes to fit {n_bytes} bytes")
+
+    def range_lookup(self, input: int, range: int):
+        self.tables.fixed_lookup([FixedTableTag.range_table_tag(range), input, 0, 0])
 
     def byte_range_lookup(self, input: int):
-        self.tables.fixed_lookup([FixedTableTag.Range256, input, 0, 0])
+        self.range_lookup(input, 256)
 
     def fixed_lookup(self, tag: FixedTableTag, inputs: Sequence[int]) -> Array4:
         return self.tables.fixed_lookup([tag] + inputs)
 
-    def block_lookup(self, tag: BlockContextFieldTag, index: int = 0) -> int:
+    def block_context_lookup(self, tag: BlockContextFieldTag, index: int = 0) -> int:
         return self.tables.block_lookup([tag, index])[2]
 
-    def tx_lookup(self, tx_id: int, tag: TxContextFieldTag, index: int = 0) -> int:
-        return self.tables.tx_lookup([tx_id, tag, index])[3]
+    def tx_context_lookup(self, tx_id: int, field_tag: TxContextFieldTag) -> Union[int, RLC]:
+        return self.tables.tx_lookup([tx_id, field_tag, 0])[3]
+
+    def tx_calldata_lookup(self, tx_id: int, index: int) -> int:
+        return self.tables.tx_lookup([tx_id, TxContextFieldTag.CallData, index])[3]
 
     def bytecode_lookup(self, bytecode_hash: int, index: int, is_code: int) -> int:
         return self.tables.bytecode_lookup([bytecode_hash, index, Tables._, is_code])[2]
+
+    def tx_gas_price(self, tx_id: int) -> int:
+        return self.tx_context_lookup(tx_id, TxContextFieldTag.GasPrice)
+
+    def responsible_opcode_lookup(self, opcode: int):
+        self.fixed_lookup(FixedTableTag.ResponsibleOpcode, [self.curr.execution_state, opcode])
 
     def opcode_lookup(self, is_code: bool) -> int:
         index = self.curr.program_counter + self.program_counter_offset
@@ -257,7 +338,7 @@ class Instruction:
                 "The opcode source when is_root and is_create (root creation call) is not determined yet"
             )
         else:
-            return self.bytecode_lookup(self.curr.opcode_source, index, is_code)
+            return self.bytecode_lookup(self.curr.code_source, index, is_code)
 
     def rw_lookup(self, rw: RW, tag: RWTableTag, inputs: Sequence[int], rw_counter: Optional[int] = None) -> Array8:
         if rw_counter is None:
@@ -285,47 +366,66 @@ class Instruction:
         inputs: Sequence[int],
         is_persistent: bool,
         rw_counter_end_of_reversion: int,
+        state_write_counter: Optional[int] = None,
     ) -> Array8:
         assert tag.write_with_reversion()
 
         row = self.rw_lookup(RW.Write, tag, inputs)
 
-        rw_counter = rw_counter_end_of_reversion - self.curr.state_write_counter - self.state_write_counter_offset
-        self.state_write_counter_offset += 1
+        if state_write_counter is None:
+            state_write_counter = self.curr.state_write_counter + self.state_write_counter_offset
+            self.state_write_counter_offset += 1
+
+        rw_counter = rw_counter_end_of_reversion - state_write_counter
 
         if not is_persistent:
             # Swap value and value_prev
             inputs = list(row[3:])
             if tag == RWTableTag.TxAccessListAccount:
                 inputs[2], inputs[3] = inputs[3], inputs[2]
-            elif tag == RWTableTag.TxAccessListStorageSlot:
+            elif tag == RWTableTag.TxAccessListAccountStorage:
                 inputs[3], inputs[4] = inputs[4], inputs[3]
             elif tag == RWTableTag.Account:
                 inputs[2], inputs[3] = inputs[3], inputs[2]
             elif tag == RWTableTag.AccountStorage:
-                inputs[3], inputs[4] = inputs[4], inputs[3]
+                inputs[2], inputs[3] = inputs[3], inputs[2]
             self.rw_lookup(RW.Write, tag, inputs, rw_counter=rw_counter)
 
         return row
 
-    def call_context_lookup(self, tag: CallContextFieldTag, rw: RW = RW.Read, call_id: Union[int, None] = None) -> int:
+    def call_context_lookup(
+        self, field_tag: CallContextFieldTag, rw: RW = RW.Read, call_id: Optional[int] = None
+    ) -> int:
         if call_id is None:
             call_id = self.curr.call_id
 
-        return self.rw_lookup(rw, RWTableTag.CallContext, [call_id, tag])[5]
+        return self.rw_lookup(rw, RWTableTag.CallContext, [call_id, field_tag])[5]
 
-    def stack_pop(self) -> int:
+    def stack_pop(self) -> Union[int, RLC]:
         stack_pointer_offset = self.stack_pointer_offset
         self.stack_pointer_offset += 1
         return self.stack_lookup(False, stack_pointer_offset)
 
-    def stack_push(self) -> int:
+    def stack_push(self) -> Union[int, RLC]:
         self.stack_pointer_offset -= 1
         return self.stack_lookup(True, self.stack_pointer_offset)
 
-    def stack_lookup(self, rw: RW, stack_pointer_offset: int) -> int:
+    def stack_lookup(self, rw: RW, stack_pointer_offset: int) -> Union[int, RLC]:
         stack_pointer = self.curr.stack_pointer + stack_pointer_offset
         return self.rw_lookup(rw, RWTableTag.Stack, [self.curr.call_id, stack_pointer])[5]
+
+    def memory_write(self, memory_address: int, call_id: Optional[int] = None) -> int:
+        return self.memory_lookup(RW.Write, memory_address, call_id)
+
+    def memory_lookup(self, rw: RW, memory_address: int, call_id: Optional[int] = None) -> int:
+        if call_id is None:
+            call_id = self.curr.call_id
+
+        return self.rw_lookup(rw, RWTableTag.Memory, [call_id, memory_address])[5]
+
+    def account_read(self, account_address: int, account_field_tag: AccountFieldTag) -> int:
+        row = self.rw_lookup(RW.Read, RWTableTag.Account, [account_address, account_field_tag])
+        return row[5]
 
     def account_write(
         self,
@@ -345,20 +445,23 @@ class Instruction:
         account_field_tag: AccountFieldTag,
         is_persistent: bool,
         rw_counter_end_of_reversion: int,
+        state_write_counter: Optional[int] = None,
     ) -> Tuple[int, int]:
         row = self.state_write_with_reversion(
             RWTableTag.Account,
             [account_address, account_field_tag],
             is_persistent,
             rw_counter_end_of_reversion,
+            state_write_counter,
         )
         return row[5], row[6]
 
-    def add_balance(self, account_address: int, values: Sequence[int]):
+    def add_balance(self, account_address: int, values: Sequence[int]) -> Tuple[int, int]:
         balance, balance_prev = self.account_write(account_address, AccountFieldTag.Balance)
         result, carry = self.add_words([balance_prev, *values])
         self.constrain_equal(balance, result)
         self.constrain_zero(carry)
+        return balance, balance_prev
 
     def add_balance_with_reversion(
         self,
@@ -366,19 +469,22 @@ class Instruction:
         values: Sequence[int],
         is_persistent: bool,
         rw_counter_end_of_reversion: int,
-    ):
+        state_write_counter: Optional[int] = None,
+    ) -> Tuple[int, int]:
         balance, balance_prev = self.account_write_with_reversion(
-            account_address, AccountFieldTag.Balance, is_persistent, rw_counter_end_of_reversion
+            account_address, AccountFieldTag.Balance, is_persistent, rw_counter_end_of_reversion, state_write_counter
         )
         result, carry = self.add_words([balance_prev, *values])
         self.constrain_equal(balance, result)
         self.constrain_zero(carry)
+        return balance, balance_prev
 
-    def sub_balance(self, account_address: int, values: Sequence[int]):
+    def sub_balance(self, account_address: int, values: Sequence[int]) -> Tuple[int, int]:
         balance, balance_prev = self.account_write(account_address, AccountFieldTag.Balance)
         result, carry = self.add_words([balance, *values])
         self.constrain_equal(balance_prev, result)
         self.constrain_zero(carry)
+        return balance, balance_prev
 
     def sub_balance_with_reversion(
         self,
@@ -386,17 +492,15 @@ class Instruction:
         values: Sequence[int],
         is_persistent: bool,
         rw_counter_end_of_reversion: int,
-    ):
+        state_write_counter: Optional[int] = None,
+    ) -> Tuple[int, int]:
         balance, balance_prev = self.account_write_with_reversion(
-            account_address, AccountFieldTag.Balance, is_persistent, rw_counter_end_of_reversion
+            account_address, AccountFieldTag.Balance, is_persistent, rw_counter_end_of_reversion, state_write_counter
         )
         result, carry = self.add_words([balance, *values])
         self.constrain_equal(balance_prev, result)
         self.constrain_zero(carry)
-
-    def account_read(self, account_address: int, account_field_tag: AccountFieldTag) -> Tuple[int, int]:
-        row = self.rw_lookup(RW.Read, RWTableTag.Account, [account_address, account_field_tag])
-        return row[5], row[6]
+        return balance, balance_prev
 
     def add_account_to_access_list(
         self,
@@ -416,40 +520,45 @@ class Instruction:
         account_address: int,
         is_persistent: bool,
         rw_counter_end_of_reversion: int,
+        state_write_counter: Optional[int] = None,
     ) -> bool:
         row = self.state_write_with_reversion(
             RWTableTag.TxAccessListAccount,
             [tx_id, account_address, 1],
             is_persistent,
             rw_counter_end_of_reversion,
+            state_write_counter,
         )
         return row[5] - row[6]
 
-    def add_storage_slot_to_access_list(
+    def add_account_storage_to_access_list(
         self,
         tx_id: int,
         account_address: int,
-        storage_slot: int,
+        storage_key: int,
     ) -> bool:
-        row = self.state_write_with_reversion(
-            RWTableTag.TxAccessListAccount,
-            [tx_id, account_address, storage_slot, 1],
+        row = self.rw_lookup(
+            RW.Write,
+            RWTableTag.TxAccessListAccountStorage,
+            [tx_id, account_address, storage_key, 1],
         )
         return row[6] - row[7]
 
-    def add_storage_slot_to_access_list_with_reversion(
+    def add_account_storage_to_access_list_with_reversion(
         self,
         tx_id: int,
         account_address: int,
-        storage_slot: int,
+        storage_key: int,
         is_persistent: bool,
         rw_counter_end_of_reversion: int,
+        state_write_counter: Optional[int] = None,
     ) -> bool:
         row = self.state_write_with_reversion(
-            RWTableTag.TxAccessListAccount,
-            [tx_id, account_address, storage_slot, 1],
+            RWTableTag.TxAccessListAccountStorage,
+            [tx_id, account_address, storage_key, 1],
             is_persistent,
             rw_counter_end_of_reversion,
+            state_write_counter,
         )
         return row[6] - row[7]
 
@@ -461,16 +570,88 @@ class Instruction:
         gas_fee: int,
         is_persistent: bool,
         rw_counter_end_of_reversion: int,
-    ):
-        self.sub_balance_with_reversion(
+    ) -> Tuple[Tuple[int, int], Tuple[int, int]]:
+        sender_balance_pair = self.sub_balance_with_reversion(
             sender_address,
             [value, gas_fee],
             is_persistent,
             rw_counter_end_of_reversion,
         )
-        self.add_balance_with_reversion(
+        receiver_balance_pair = self.add_balance_with_reversion(
             receiver_address,
             [value],
             is_persistent,
             rw_counter_end_of_reversion,
         )
+        return sender_balance_pair, receiver_balance_pair
+
+    def transfer(
+        self,
+        sender_address: int,
+        receiver_address: int,
+        value: int,
+        is_persistent: bool,
+        rw_counter_end_of_reversion: int,
+        state_write_counter: Optional[int] = None,
+    ) -> Tuple[Tuple[int, int], Tuple[int, int]]:
+        sender_balance_pair = self.sub_balance_with_reversion(
+            sender_address,
+            [value],
+            is_persistent,
+            rw_counter_end_of_reversion,
+            state_write_counter,
+        )
+        receiver_balance_pair = self.add_balance_with_reversion(
+            receiver_address,
+            [value],
+            is_persistent,
+            rw_counter_end_of_reversion,
+            None if state_write_counter is None else state_write_counter + 1,
+        )
+        return sender_balance_pair, receiver_balance_pair
+
+    def memory_offset_and_length_to_int(self, offset: RLC, length: RLC) -> Tuple[int, int]:
+        length = self.rlc_to_int_exact(length, N_BYTES_MEMORY_ADDRESS)
+        if self.is_zero(length):
+            return 0, 0
+
+        offset = self.rlc_to_int_exact(offset, N_BYTES_MEMORY_ADDRESS)
+        return offset, length
+
+    def memory_gas_cost(self, memory_size: int) -> int:
+        quadratic_cost, _ = self.constant_divmod(
+            memory_size * memory_size, MEMORY_EXPANSION_QUAD_DENOMINATOR, N_BYTES_GAS
+        )
+        linear_cost = MEMORY_EXPANSION_LINEAR_COEFF * memory_size
+        return quadratic_cost + linear_cost
+
+    def memory_expansion_constant_length(self, offset: int, length: int) -> Tuple[int, int]:
+        memory_size, _ = self.constant_divmod(length + offset + 31, 32, N_BYTES_MEMORY_SIZE)
+
+        next_memory_size = self.max(self.curr.memory_size, memory_size, N_BYTES_MEMORY_SIZE)
+
+        memory_gas_cost = self.memory_gas_cost(self.curr.memory_size)
+        memory_gas_cost_next = self.memory_gas_cost(next_memory_size)
+        memory_expansion_gas_cost = memory_gas_cost_next - memory_gas_cost
+
+        return next_memory_size, memory_expansion_gas_cost
+
+    def memory_expansion_dynamic_length(
+        self,
+        cd_offset: int,
+        cd_length: int,
+        rd_offset: Optional[int] = None,
+        rd_length: Optional[int] = None,
+    ) -> Tuple[int, int]:
+        cd_memory_size, _ = self.constant_divmod(cd_offset + cd_length + 31, 32, N_BYTES_MEMORY_SIZE)
+        next_memory_size = self.max(self.curr.memory_size, cd_memory_size, N_BYTES_MEMORY_SIZE)
+
+        if rd_offset is not None:
+            rd_memory_size, _ = self.constant_divmod(rd_offset + rd_length + 31, 32, N_BYTES_MEMORY_SIZE)
+            next_memory_size = self.max(next_memory_size, rd_memory_size, N_BYTES_MEMORY_SIZE)
+
+        memory_gas_cost = self.memory_gas_cost(self.curr.memory_size)
+        memory_gas_cost_next = self.memory_gas_cost(next_memory_size)
+        memory_expansion_gas_cost = memory_gas_cost_next - memory_gas_cost
+
+        return next_memory_size, memory_expansion_gas_cost

--- a/src/zkevm_specs/evm/main.py
+++ b/src/zkevm_specs/evm/main.py
@@ -12,19 +12,19 @@ def verify_steps(
     tables: Tables,
     steps: Sequence[StepState],
     begin_with_first_step: bool = False,
-    end_with_final_step: bool = False,
+    end_with_last_step: bool = False,
 ):
     # TODO: Enforce general ExecutionState transition constraint
 
-    for idx in range(len(steps) - 1):
+    for idx in range(len(steps) if end_with_last_step else len(steps) - 1):
         verify_step(
             Instruction(
                 randomness=randomness,
                 tables=tables,
                 curr=steps[idx],
-                next=steps[idx + 1],
+                next=steps[idx + 1] if idx + 1 < len(steps) else None,
                 is_first_step=begin_with_first_step and idx == 0,
-                is_last_step=end_with_final_step and idx == len(steps) - 2,
+                is_last_step=idx + 1 == len(steps),
             ),
         )
 

--- a/src/zkevm_specs/evm/main.py
+++ b/src/zkevm_specs/evm/main.py
@@ -39,7 +39,4 @@ def verify_step(
         raise NotImplementedError
 
     if instruction.is_last_step:
-        # Verify no malicious insertion
-        assert instruction.curr.rw_counter == len(instruction.tables.rw_table)
-
-        # TODO: Verify final step has the tx_id identical to the amount in tx_table
+        instruction.constrain_equal(instruction.curr.execution_state, ExecutionState.EndBlock)

--- a/src/zkevm_specs/evm/main.py
+++ b/src/zkevm_specs/evm/main.py
@@ -14,6 +14,8 @@ def verify_steps(
     begin_with_first_step: bool = False,
     end_with_final_step: bool = False,
 ):
+    # TODO: Enforce general ExecutionState transition constraint
+
     for idx in range(len(steps) - 1):
         verify_step(
             Instruction(

--- a/src/zkevm_specs/evm/opcode.py
+++ b/src/zkevm_specs/evm/opcode.py
@@ -149,6 +149,24 @@ class Opcode(IntEnum):
     def hex(self) -> str:
         return "{:02x}".format(self)
 
+    def bytes(self) -> bytes:
+        return bytes([self])
+
+    def is_push(self) -> bool:
+        return Opcode.PUSH1 <= self <= Opcode.PUSH32
+
+    def is_dup(self) -> bool:
+        return Opcode.DUP1 <= self <= Opcode.DUP16
+
+    def is_swap(self) -> bool:
+        return Opcode.SWAP1 <= self <= Opcode.SWAP16
+
+    def max_stack_pointer(self) -> int:
+        return OPCODE_INFO_MAP[self].max_stack_pointer
+
+    def min_stack_pointer(self) -> int:
+        return OPCODE_INFO_MAP[self].min_stack_pointer
+
     def constant_gas_cost(self) -> int:
         return OPCODE_INFO_MAP[self].constant_gas_cost
 
@@ -339,15 +357,14 @@ def valid_opcodes() -> Sequence[Opcode]:
 
 
 def invalid_opcodes() -> Sequence[int]:
-    return [opcode for opcode in range(256) if opcode not in OPCODE_INFO_MAP]
+    return [opcode for opcode in range(256) if opcode not in valid_opcodes()]
 
 
 def stack_overflow_pairs() -> Sequence[Tuple[int, int]]:
     pairs = []
     for opcode in valid_opcodes():
-        opcode_info = OPCODE_INFO_MAP[opcode]
-        if opcode_info.min_stack_pointer > 0:
-            for stack_pointer in range(opcode_info.min_stack_pointer):
+        if opcode.min_stack_pointer() > 0:
+            for stack_pointer in range(opcode.min_stack_pointer()):
                 pairs.append((opcode, stack_pointer))
     return pairs
 
@@ -355,9 +372,8 @@ def stack_overflow_pairs() -> Sequence[Tuple[int, int]]:
 def stack_underflow_pairs() -> Sequence[Tuple[int, int]]:
     pairs = []
     for opcode in valid_opcodes():
-        opcode_info = OPCODE_INFO_MAP[opcode]
-        if opcode_info.max_stack_pointer < 1024:
-            for stack_pointer in range(opcode_info.max_stack_pointer, 1024):
+        if opcode.max_stack_pointer() < 1024:
+            for stack_pointer in range(opcode.max_stack_pointer(), 1024):
                 pairs.append((opcode, stack_pointer + 1))
     return pairs
 

--- a/src/zkevm_specs/evm/step.py
+++ b/src/zkevm_specs/evm/step.py
@@ -6,7 +6,7 @@ class StepState:
     Step state EVM circuit tracks step by step and used to ensure the
     execution trace is verified continuously and chronologically.
     It includes fields that are used from beginning to end like is_root,
-    is_create and opcode_source.
+    is_create and code_source.
     It also includes call's mutable states which change almost every step like
     program_counter and stack_pointer.
     """
@@ -18,15 +18,15 @@ class StepState:
     # The following 3 fields decide the opcode source. There are 2 possible
     # cases:
     # 1. Root creation call (is_root and is_create)
-    #   It was planned to set the opcode_source to tx_id, then lookup tx_table's
+    #   It was planned to set the code_source to tx_id, then lookup tx_table's
     #   CallData field directly, but is still yet to be determined.
     #   See the issue https://github.com/appliedzkp/zkevm-specs/issues/73 for
     #   further discussion.
     # 2. Deployed contract interaction or internal creation call
-    #   We set opcode_source to bytecode_hash and lookup bytecode_table.
+    #   We set code_source to bytecode_hash and lookup bytecode_table.
     is_root: bool
     is_create: bool
-    opcode_source: int
+    code_source: int
 
     # The following fields change almost every step.
     program_counter: int
@@ -45,10 +45,10 @@ class StepState:
         self,
         execution_state: ExecutionState,
         rw_counter: int,
-        call_id: int,
+        call_id: int = 0,
         is_root: bool = False,
         is_create: bool = False,
-        opcode_source: int = 0,
+        code_source: int = 0,
         program_counter: int = 0,
         stack_pointer: int = 1024,
         gas_left: int = 0,
@@ -63,7 +63,7 @@ class StepState:
         self.call_id = call_id
         self.is_root = is_root
         self.is_create = is_create
-        self.opcode_source = opcode_source
+        self.code_source = code_source
         self.program_counter = program_counter
         self.stack_pointer = stack_pointer
         self.gas_left = gas_left

--- a/src/zkevm_specs/evm/table.py
+++ b/src/zkevm_specs/evm/table.py
@@ -107,11 +107,11 @@ class BlockContextFieldTag(IntEnum):
 
     Coinbase = auto()
     GasLimit = auto()
-    BlockNumber = auto()
-    Time = auto()
+    Number = auto()
+    Timestamp = auto()
     Difficulty = auto()
     BaseFee = auto()
-    BlockHash = auto()
+    HistoryHash = auto()
 
 
 class TxContextFieldTag(IntEnum):
@@ -262,14 +262,14 @@ class Tables:
 
     # Each row in BlockTable contains:
     # - tag
-    # - block_number_or_zero (meaningful only for BlockHash, will be zero for other tags)
+    # - block_number_or_zero (meaningful only for HistoryHash, will be zero for other tags)
     # - value
     block_table: Set[Array3]
 
     # Each row in TxTable contains:
     # - tx_id
     # - tag
-    # - index_or_zero (meaningful only for CallData, will be zero for other tags)
+    # - call_data_index_or_zero (meaningful only for CallData, will be zero for other tags)
     # - value
     tx_table: Set[Array4]
 

--- a/src/zkevm_specs/evm/table.py
+++ b/src/zkevm_specs/evm/table.py
@@ -54,7 +54,7 @@ class FixedTableTag(IntEnum):
         elif self == FixedTableTag.Range1024:
             return [(self, i, 0, 0) for i in range(1024)]
         elif self == FixedTableTag.SignByte:
-            return [(self, i, (i & 1) * 0xFF, 0) for i in range(256)]
+            return [(self, i, (i >> 7) * 0xFF, 0) for i in range(256)]
         elif self == FixedTableTag.BitwiseAnd:
             return [(self, lhs, rhs, lhs & rhs) for lhs, rhs in product(range(256), range(256))]
         elif self == FixedTableTag.BitwiseOr:

--- a/src/zkevm_specs/evm/table.py
+++ b/src/zkevm_specs/evm/table.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
 from typing import Sequence, Set, Tuple
 from enum import IntEnum, auto
+from itertools import chain, product
 
 from ..util import Array3, Array4, Array8
 from .execution_state import ExecutionState
@@ -37,6 +39,62 @@ class FixedTableTag(IntEnum):
     StateWriteOpcode = auto()  # opcode, 0, 0
     StackOverflow = auto()  # opcode, stack_pointer, 0
     StackUnderflow = auto()  # opcode, stack_pointer, 0
+
+    def table_assignments(self) -> Sequence[Array4]:
+        if self == FixedTableTag.Range16:
+            return [(self, i, 0, 0) for i in range(16)]
+        elif self == FixedTableTag.Range32:
+            return [(self, i, 0, 0) for i in range(32)]
+        elif self == FixedTableTag.Range64:
+            return [(self, i, 0, 0) for i in range(64)]
+        elif self == FixedTableTag.Range256:
+            return [(self, i, 0, 0) for i in range(256)]
+        elif self == FixedTableTag.Range512:
+            return [(self, i, 0, 0) for i in range(512)]
+        elif self == FixedTableTag.Range1024:
+            return [(self, i, 0, 0) for i in range(1024)]
+        elif self == FixedTableTag.SignByte:
+            return [(self, i, (i & 1) * 0xFF, 0) for i in range(256)]
+        elif self == FixedTableTag.BitwiseAnd:
+            return [(self, lhs, rhs, lhs & rhs) for lhs, rhs in product(range(256), range(256))]
+        elif self == FixedTableTag.BitwiseOr:
+            return [(self, lhs, rhs, lhs | rhs) for lhs, rhs in product(range(256), range(256))]
+        elif self == FixedTableTag.BitwiseXor:
+            return [(self, lhs, rhs, lhs ^ rhs) for lhs, rhs in product(range(256), range(256))]
+        elif self == FixedTableTag.ResponsibleOpcode:
+            return [
+                (self, execution_state, opcode, 0)
+                for execution_state in list(ExecutionState)
+                for opcode in execution_state.responsible_opcode()
+            ]
+        elif self == FixedTableTag.InvalidOpcode:
+            return [(self, opcode, 0, 0) for opcode in invalid_opcodes()]
+        elif self == FixedTableTag.StateWriteOpcode:
+            return [(self, opcode, 0, 0) for opcode in state_write_opcodes()]
+        elif self == FixedTableTag.StackOverflow:
+            return [(self, opcode, stack_pointer, 0) for opcode, stack_pointer in stack_underflow_pairs()]
+        elif self == FixedTableTag.StackUnderflow:
+            return [(self, opcode, stack_pointer, 0) for opcode, stack_pointer in stack_overflow_pairs()]
+        else:
+            ValueError("Unreacheable")
+
+    def range_table_tag(range: int) -> FixedTableTag:
+        if range == 16:
+            return FixedTableTag.Range16
+        elif range == 32:
+            return FixedTableTag.Range32
+        elif range == 64:
+            return FixedTableTag.Range64
+        elif range == 256:
+            return FixedTableTag.Range256
+        elif range == 512:
+            return FixedTableTag.Range512
+        elif range == 1024:
+            return FixedTableTag.Range1024
+        else:
+            raise ValueError(
+                f"Range {range} lookup is not supported yet, please add a new variant Range{range} in FixedTableTag with proper table assignments"
+            )
 
 
 class BlockContextFieldTag(IntEnum):
@@ -89,7 +147,7 @@ class RWTableTag(IntEnum):
     """
 
     TxAccessListAccount = auto()
-    TxAccessListStorageSlot = auto()
+    TxAccessListAccountStorage = auto()
     TxRefund = auto()
 
     Account = auto()
@@ -105,7 +163,7 @@ class RWTableTag(IntEnum):
     def write_with_reversion(self) -> bool:
         return self in [
             RWTableTag.TxAccessListAccount,
-            RWTableTag.TxAccessListStorageSlot,
+            RWTableTag.TxAccessListAccountStorage,
             RWTableTag.Account,
             RWTableTag.AccountStorage,
         ]
@@ -138,8 +196,8 @@ class CallContextFieldTag(IntEnum):
     # It's not like transaction or bytecode that require specifically friendly
     # layout for verification, so maintaining the consistency directly in
     # RWTable seems more intuitive than creating another table for it.
-    RWCounterEndOfReversion = auto()  # to know at which point in the future we should revert
-    CallerCallId = auto()  # to know caller's id
+    RwCounterEndOfReversion = auto()  # to know at which point in the future we should revert
+    CallerId = auto()  # to know caller's id
     TxId = auto()  # to know tx's id
     Depth = auto()  # to know if call too deep
     CallerAddress = auto()
@@ -149,9 +207,16 @@ class CallContextFieldTag(IntEnum):
     ReturnDataOffset = auto()  # for callee to set return_data to caller's memeory
     ReturnDataLength = auto()
     Value = auto()
-    Result = auto()  # to peek result in the future
+    IsSuccess = auto()  # to peek result in the future
     IsPersistent = auto()  # to know if current call is within reverted call or not
     IsStatic = auto()  # to know if state modification is within static call or not
+
+    # The following are read-only data inside a call like previous section for
+    # opcode RETURNDATASIZE and RETURNDATACOPY, except they will be updated when
+    # end of callee execution.
+    LastCalleeId = auto()
+    LastCalleeReturnDataOffset = auto()
+    LastCalleeReturnDataLength = auto()
 
     # The following are used by caller to save its own CallState when it's
     # going to dive into another call, and will be read out to restore caller's
@@ -161,7 +226,7 @@ class CallContextFieldTag(IntEnum):
     # different kinds of RWTableTag.
     IsRoot = auto()
     IsCreate = auto()
-    OpcodeSource = auto()
+    CodeSource = auto()
     ProgramCounter = auto()
     StackPointer = auto()
     GasLeft = auto()
@@ -193,33 +258,7 @@ class Tables:
     # - value1
     # - value2
     # - value3
-    fixed_table: Set[Array4] = set(
-        [(FixedTableTag.Range16, i, 0, 0) for i in range(16)]
-        + [(FixedTableTag.Range32, i, 0, 0) for i in range(32)]
-        + [(FixedTableTag.Range64, i, 0, 0) for i in range(64)]
-        + [(FixedTableTag.Range256, i, 0, 0) for i in range(256)]
-        + [(FixedTableTag.Range512, i, 0, 0) for i in range(512)]
-        + [(FixedTableTag.Range1024, i, 0, 0) for i in range(1024)]
-        + [(FixedTableTag.SignByte, i, (i & 1) * 0xFF, 0) for i in range(256)]
-        + [(FixedTableTag.BitwiseAnd, lhs, rhs, lhs & rhs) for lhs in range(256) for rhs in range(256)]
-        + [(FixedTableTag.BitwiseOr, lhs, rhs, lhs | rhs) for lhs in range(256) for rhs in range(256)]
-        + [(FixedTableTag.BitwiseXor, lhs, rhs, lhs ^ rhs) for lhs in range(256) for rhs in range(256)]
-        + [
-            (FixedTableTag.ResponsibleOpcode, execution_state, opcode, 0)
-            for execution_state in list(ExecutionState)
-            for opcode in execution_state.responsible_opcode()
-        ]
-        + [(FixedTableTag.InvalidOpcode, opcode, 0, 0) for opcode in invalid_opcodes()]
-        + [(FixedTableTag.StateWriteOpcode, opcode, 0, 0) for opcode in state_write_opcodes()]
-        + [
-            (FixedTableTag.StackUnderflow, opcode, stack_pointer, 0)
-            for (opcode, stack_pointer) in stack_underflow_pairs()
-        ]
-        + [
-            (FixedTableTag.StackOverflow, opcode, stack_pointer, 0)
-            for (opcode, stack_pointer) in stack_overflow_pairs()
-        ]
-    )
+    fixed_table: Set[Array4] = set(chain(*[tag.table_assignments() for tag in list(FixedTableTag)]))
 
     # Each row in BlockTable contains:
     # - tag

--- a/src/zkevm_specs/evm/typing.py
+++ b/src/zkevm_specs/evm/typing.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Any, Iterator, Optional, Sequence
+from typing import Any, Dict, Iterator, NewType, Optional, Sequence
 from functools import reduce
 from itertools import chain
 
@@ -13,8 +13,6 @@ from ..util import (
     keccak256,
     GAS_COST_TX_CALL_DATA_PER_NON_ZERO_BYTE,
     GAS_COST_TX_CALL_DATA_PER_ZERO_BYTE,
-    EMPTY_HASH,
-    EMPTY_TRIE_HASH,
 )
 from .table import BlockContextFieldTag, TxContextFieldTag
 from .opcode import get_push_size, Opcode
@@ -213,23 +211,32 @@ class Bytecode:
         return BytecodeIterator(RLC(self.hash(), randomness), self.code)
 
 
+Storage = NewType("Storage", Dict[U256, U256])
+
+
 class Account:
     address: U160
     nonce: U256
     balance: U256
-    code_hash: U256
-    storage_trie_hash: U256
+    code: Bytecode
+    storage: Storage
 
     def __init__(
         self,
         address: U160 = 0,
         nonce: U256 = 0,
         balance: U256 = 0,
-        code_hash: U256 = EMPTY_HASH,
-        storage_trie_hash: U256 = EMPTY_TRIE_HASH,
+        code: Optional[Bytecode] = None,
+        storage: Optional[Storage] = None,
     ) -> None:
         self.address = address
         self.nonce = nonce
         self.balance = balance
-        self.code_hash = code_hash
-        self.storage_trie_hash = storage_trie_hash
+        self.code = Bytecode() if code is None else code
+        self.storage = dict() if storage is None else storage
+
+    def code_hash(self) -> U256:
+        return self.code.hash()
+
+    def storage_trie_hash(self) -> U256:
+        raise NotImplementedError("Trie has not been implemented")

--- a/src/zkevm_specs/util/__init__.py
+++ b/src/zkevm_specs/util/__init__.py
@@ -8,12 +8,12 @@ from .param import *
 from .typing import *
 
 
-def hex_to_word(hex: str) -> bytes:
-    return bytes.fromhex(hex.removeprefix("0x").zfill(64))
-
-
 def rand_range(stop: Union[int, float] = 2 ** 256) -> int:
     return randrange(0, int(stop))
+
+
+def rand_fp() -> int:
+    return rand_range(FP_MODULUS)
 
 
 def rand_address() -> U160:

--- a/src/zkevm_specs/util/hash.py
+++ b/src/zkevm_specs/util/hash.py
@@ -1,13 +1,15 @@
 from typing import Union
 from Crypto.Hash import keccak
 
+from .typing import U256
 
-def keccak256(data: Union[str, bytes]) -> bytes:
+
+def keccak256(data: Union[str, bytes, bytearray]) -> bytes:
     if type(data) == str:
         data = bytes.fromhex(data)
     return keccak.new(digest_bits=256).update(data).digest()
 
 
-EMPTY_HASH = keccak256("")
-EMPTY_CODE_HASH = EMPTY_HASH
-EMPTY_TRIE_HASH = keccak256("80")
+EMPTY_HASH: U256 = int.from_bytes(keccak256(""), "big")
+EMPTY_CODE_HASH: U256 = EMPTY_HASH
+EMPTY_TRIE_HASH: U256 = int.from_bytes(keccak256("80"), "big")

--- a/src/zkevm_specs/util/param.py
+++ b/src/zkevm_specs/util/param.py
@@ -1,9 +1,38 @@
 # Maximun number of bytes with composition value that doesn't wrap around the field
 MAX_N_BYTES = 31
+# Number of bytes of account address
+N_BYTES_ACCOUNT_ADDRESS = 20
+# Number of bytes of memory address
+N_BYTES_MEMORY_ADDRESS = 5
+# Number of bytes of memory size (in word)
+N_BYTES_MEMORY_SIZE = 4
 # Number of bytes of gas
 N_BYTES_GAS = 8
+# Number of bytes of program counter
+N_BYTES_PROGRAM_COUNTER = 8
 
+# Gas cost of non-creation transaction
+GAS_COST_TX = 21000
+# Gas cost of creation transaction
+GAS_COST_CREATION_TX = 53000
 # Gas cost of transaction call_data per non-zero byte
 GAS_COST_TX_CALL_DATA_PER_NON_ZERO_BYTE = 16
 # Gas cost of transaction call_data per zero byte
 GAS_COST_TX_CALL_DATA_PER_ZERO_BYTE = 4
+# Gas cost of accessing account or storage slot
+GAS_COST_WARM_ACCESS = 100
+# Extra gas cost of not-yet-accessed account
+EXTRA_GAS_COST_ACCOUNT_COLD_ACCESS = 2500
+# Extra gas cost of not-yet-accessed storage slot
+EXTRA_GAS_COST_STORAGE_SLOT_COLD_ACCESS = 2000
+# Gas cost of calling with non-zero value
+GAS_COST_CALL_WITH_VALUE = 9000
+# Gas cost of calling empty account
+GAS_COST_CALL_EMPTY_ACCOUNT = 25000
+# Gas stipend given if call with non-zero value
+GAS_STIPEND_CALL_WITH_VALUE = 2300
+
+# Denominator of quadratic part of memory expansion gas cost
+MEMORY_EXPANSION_QUAD_DENOMINATOR = 512
+# Coefficient of linear part of memory expansion gas cost
+MEMORY_EXPANSION_LINEAR_COEFF = 3

--- a/src/zkevm_specs/util/param.py
+++ b/src/zkevm_specs/util/param.py
@@ -32,6 +32,8 @@ GAS_COST_CALL_EMPTY_ACCOUNT = 25000
 # Gas stipend given if call with non-zero value
 GAS_STIPEND_CALL_WITH_VALUE = 2300
 
+# Quotient for max refund of gas used
+MAX_REFUND_QUOTIENT_OF_GAS_USED = 5
 # Denominator of quadratic part of memory expansion gas cost
 MEMORY_EXPANSION_QUAD_DENOMINATOR = 512
 # Coefficient of linear part of memory expansion gas cost

--- a/tests/evm/test_add.py
+++ b/tests/evm/test_add.py
@@ -12,37 +12,32 @@ from zkevm_specs.evm import (
     Block,
     Bytecode,
 )
-from zkevm_specs.util import hex_to_word, rand_bytes, RLCStore
+from zkevm_specs.util import rand_fp, rand_word, RLC
 
 
 TESTING_DATA = (
-    (Opcode.ADD, hex_to_word("030201"), hex_to_word("060504"), hex_to_word("090705")),
-    (Opcode.SUB, hex_to_word("090705"), hex_to_word("060504"), hex_to_word("030201")),
-    (Opcode.ADD, rand_bytes(), rand_bytes(), None),
-    (Opcode.SUB, rand_bytes(), rand_bytes(), None),
+    (Opcode.ADD, 0x030201, 0x060504, 0x090705),
+    (Opcode.SUB, 0x090705, 0x060504, 0x030201),
+    (Opcode.ADD, rand_word(), rand_word(), None),
+    (Opcode.SUB, rand_word(), rand_word(), None),
 )
 
 
-@pytest.mark.parametrize("opcode, a_bytes, b_bytes, c_bytes", TESTING_DATA)
-def test_add(opcode: Opcode, a_bytes: bytes, b_bytes: bytes, c_bytes: Optional[bytes]):
-    rlc_store = RLCStore()
+@pytest.mark.parametrize("opcode, a, b, c", TESTING_DATA)
+def test_add(opcode: Opcode, a: int, b: int, c: Optional[int]):
+    randomness = rand_fp()
 
-    a = rlc_store.to_rlc(a_bytes)
-    b = rlc_store.to_rlc(b_bytes)
-    c = (
-        rlc_store.to_rlc(c_bytes)
-        if c_bytes is not None
-        else (rlc_store.add(a, b) if opcode == Opcode.ADD else rlc_store.sub(a, b))[0]
-    )
+    c = RLC(c, randomness) if c is not None else RLC((a + b if opcode == Opcode.ADD else a - b) % 2 ** 256, randomness)
+    a = RLC(a, randomness)
+    b = RLC(b, randomness)
 
-    block = Block()
-    bytecode = Bytecode(f"7f{b_bytes.hex()}7f{a_bytes.hex()}{opcode.hex()}00")
-    bytecode_hash = rlc_store.to_rlc(bytecode.hash, 32)
+    bytecode = Bytecode().add(a, b) if opcode == Opcode.ADD else Bytecode().sub(a, b)
+    bytecode_hash = RLC(bytecode.hash(), randomness)
 
     tables = Tables(
-        block_table=set(block.table_assignments(rlc_store)),
+        block_table=set(Block().table_assignments(randomness)),
         tx_table=set(),
-        bytecode_table=set(bytecode.table_assignments(rlc_store)),
+        bytecode_table=set(bytecode.table_assignments(randomness)),
         rw_table=set(
             [
                 (9, RW.Read, RWTableTag.Stack, 1, 1022, a, 0, 0),
@@ -53,7 +48,7 @@ def test_add(opcode: Opcode, a_bytes: bytes, b_bytes: bytes, c_bytes: Optional[b
     )
 
     verify_steps(
-        rlc_store=rlc_store,
+        randomness=randomness,
         tables=tables,
         steps=[
             StepState(
@@ -62,7 +57,7 @@ def test_add(opcode: Opcode, a_bytes: bytes, b_bytes: bytes, c_bytes: Optional[b
                 call_id=1,
                 is_root=True,
                 is_create=False,
-                opcode_source=bytecode_hash,
+                code_source=bytecode_hash,
                 program_counter=66,
                 stack_pointer=1022,
                 gas_left=3,
@@ -73,7 +68,7 @@ def test_add(opcode: Opcode, a_bytes: bytes, b_bytes: bytes, c_bytes: Optional[b
                 call_id=1,
                 is_root=True,
                 is_create=False,
-                opcode_source=bytecode_hash,
+                code_source=bytecode_hash,
                 program_counter=67,
                 stack_pointer=1023,
                 gas_left=0,

--- a/tests/evm/test_coinbase.py
+++ b/tests/evm/test_coinbase.py
@@ -3,7 +3,6 @@ import pytest
 from zkevm_specs.evm import (
     ExecutionState,
     StepState,
-    Opcode,
     verify_steps,
     Tables,
     RWTableTag,
@@ -11,34 +10,34 @@ from zkevm_specs.evm import (
     Block,
     Bytecode,
 )
-from zkevm_specs.util import RLCStore, U160
+from zkevm_specs.util import rand_address, rand_fp, RLC, U160
 
 
-TESTING_DATA = ((Opcode.COINBASE, 0x030201),)
+TESTING_DATA = (0x030201, rand_address())
 
 
-@pytest.mark.parametrize("opcode, address", TESTING_DATA)
-def test_coinbase(opcode: Opcode, address: U160):
-    rlc_store = RLCStore()
+@pytest.mark.parametrize("coinbase", TESTING_DATA)
+def test_coinbase(coinbase: U160):
+    randomness = rand_fp()
 
-    coinbase_rlc = rlc_store.to_rlc(address.to_bytes(20, "little"))
+    block = Block(coinbase=coinbase)
 
-    bytecode = Bytecode(f"{opcode.hex()}00")
-    bytecode_hash = rlc_store.to_rlc(bytecode.hash, 32)
-    block = Block(address)
+    bytecode = Bytecode().coinbase()
+    bytecode_hash = RLC(bytecode.hash(), randomness)
+
     tables = Tables(
-        block_table=set(block.table_assignments(rlc_store)),
+        block_table=set(block.table_assignments(randomness)),
         tx_table=set(),
-        bytecode_table=set(bytecode.table_assignments(rlc_store)),
+        bytecode_table=set(bytecode.table_assignments(randomness)),
         rw_table=set(
             [
-                (9, RW.Write, RWTableTag.Stack, 1, 1023, coinbase_rlc, 0, 0),
+                (9, RW.Write, RWTableTag.Stack, 1, 1023, RLC(coinbase, randomness, 20), 0, 0),
             ]
         ),
     )
 
     verify_steps(
-        rlc_store=rlc_store,
+        randomness=randomness,
         tables=tables,
         steps=[
             StepState(
@@ -47,7 +46,7 @@ def test_coinbase(opcode: Opcode, address: U160):
                 call_id=1,
                 is_root=True,
                 is_create=False,
-                opcode_source=bytecode_hash,
+                code_source=bytecode_hash,
                 program_counter=0,
                 stack_pointer=1024,
                 gas_left=2,
@@ -58,7 +57,7 @@ def test_coinbase(opcode: Opcode, address: U160):
                 call_id=1,
                 is_root=True,
                 is_create=False,
-                opcode_source=bytecode_hash,
+                code_source=bytecode_hash,
                 program_counter=1,
                 stack_pointer=1023,
                 gas_left=0,

--- a/tests/evm/test_end_block.py
+++ b/tests/evm/test_end_block.py
@@ -1,0 +1,57 @@
+import pytest
+from itertools import chain
+
+from zkevm_specs.evm import (
+    ExecutionState,
+    StepState,
+    verify_steps,
+    Tables,
+    RWTableTag,
+    RW,
+    CallContextFieldTag,
+    Block,
+    Transaction,
+)
+from zkevm_specs.util import rand_fp
+
+TESTING_DATA = (False, True)
+
+
+@pytest.mark.parametrize("is_last_step", TESTING_DATA)
+def test_end_block(is_last_step: bool):
+    randomness = rand_fp()
+
+    tx = Transaction()
+
+    tables = Tables(
+        block_table=set(Block().table_assignments(randomness)),
+        tx_table=set(tx.table_assignments(randomness)),
+        bytecode_table=set(),
+        rw_table=set(
+            chain(
+                # dummy read/write for counting
+                [(i, *7 * [0]) for i in range(22)],
+                [(22, RW.Read, RWTableTag.CallContext, 1, CallContextFieldTag.TxId, tx.id, 0, 0)]
+                if is_last_step
+                else [],
+            )
+        ),
+    )
+
+    verify_steps(
+        randomness=randomness,
+        tables=tables,
+        steps=[
+            StepState(
+                execution_state=ExecutionState.EndBlock,
+                rw_counter=22,
+                call_id=1,
+            ),
+            StepState(
+                execution_state=ExecutionState.EndBlock,
+                rw_counter=22,
+                call_id=1,
+            ),
+        ],
+        end_with_last_step=is_last_step,
+    )

--- a/tests/evm/test_end_tx.py
+++ b/tests/evm/test_end_tx.py
@@ -1,0 +1,113 @@
+import pytest
+
+from zkevm_specs.evm import (
+    ExecutionState,
+    StepState,
+    verify_steps,
+    Tables,
+    RWTableTag,
+    RW,
+    AccountFieldTag,
+    CallContextFieldTag,
+    Block,
+    Transaction,
+)
+from zkevm_specs.util import rand_fp, RLC, EMPTY_CODE_HASH, MAX_REFUND_QUOTIENT_OF_GAS_USED
+
+CALLEE_ADDRESS = 0xFF
+
+TESTING_DATA = (
+    # Tx with non-capped refund
+    (
+        Transaction(caller_address=0xFE, callee_address=CALLEE_ADDRESS, gas=27000, gas_price=int(2e9)),
+        994,
+        4800,
+        False,
+    ),
+    # Tx with capped refund
+    (
+        Transaction(caller_address=0xFE, callee_address=CALLEE_ADDRESS, gas=65000, gas_price=int(2e9)),
+        3952,
+        38400,
+        False,
+    ),
+    # Last tx
+    (
+        Transaction(caller_address=0xFE, callee_address=CALLEE_ADDRESS, gas=21000, gas_price=int(2e9)),
+        0,
+        0,
+        True,
+    ),
+)
+
+
+@pytest.mark.parametrize("tx, gas_left, refund, is_last_tx", TESTING_DATA)
+def test_end_tx(tx: Transaction, gas_left: int, refund: int, is_last_tx: bool):
+    randomness = rand_fp()
+
+    block = Block()
+    effective_refund = min(refund, (tx.gas - gas_left) // MAX_REFUND_QUOTIENT_OF_GAS_USED)
+    caller_balance_prev = int(1e18) - (tx.value + tx.gas * tx.gas_price)
+    caller_balance = caller_balance_prev + (gas_left + effective_refund) * tx.gas_price
+    coinbase_balance_prev = 0
+    coinbase_balance = coinbase_balance_prev + (tx.gas - gas_left) * (tx.gas_price - block.base_fee)
+
+    tables = Tables(
+        block_table=set(block.table_assignments(randomness)),
+        tx_table=set(tx.table_assignments(randomness)),
+        bytecode_table=set(),
+        rw_table=set(
+            [
+                (17, RW.Read, RWTableTag.CallContext, 1, CallContextFieldTag.TxId, tx.id, 0, 0),
+                (18, RW.Read, RWTableTag.TxRefund, tx.id, refund, refund, 0, 0),
+                (
+                    19,
+                    RW.Write,
+                    RWTableTag.Account,
+                    tx.caller_address,
+                    AccountFieldTag.Balance,
+                    RLC(caller_balance, randomness),
+                    RLC(caller_balance_prev, randomness),
+                    0,
+                ),
+                (
+                    20,
+                    RW.Write,
+                    RWTableTag.Account,
+                    block.coinbase,
+                    AccountFieldTag.Balance,
+                    RLC(coinbase_balance, randomness),
+                    RLC(coinbase_balance_prev, randomness),
+                    0,
+                ),
+            ]
+            + (
+                []
+                if is_last_tx
+                else [(21, RW.Read, RWTableTag.CallContext, 22, CallContextFieldTag.TxId, tx.id + 1, 0, 0)]
+            )
+        ),
+    )
+
+    verify_steps(
+        randomness=randomness,
+        tables=tables,
+        steps=[
+            StepState(
+                execution_state=ExecutionState.EndTx,
+                rw_counter=17,
+                call_id=1,
+                is_root=True,
+                is_create=False,
+                code_source=RLC(EMPTY_CODE_HASH, randomness),
+                program_counter=0,
+                stack_pointer=1024,
+                gas_left=gas_left,
+                state_write_counter=2,
+            ),
+            StepState(
+                execution_state=ExecutionState.EndBlock if is_last_tx else ExecutionState.BeginTx,
+                rw_counter=22 - is_last_tx,
+            ),
+        ],
+    )

--- a/tests/evm/test_jump.py
+++ b/tests/evm/test_jump.py
@@ -1,6 +1,5 @@
 import pytest
 
-from typing import Optional
 from zkevm_specs.evm import (
     ExecutionState,
     StepState,
@@ -12,7 +11,7 @@ from zkevm_specs.evm import (
     Block,
     Bytecode,
 )
-from zkevm_specs.util import hex_to_word, rand_bytes, RLCStore
+from zkevm_specs.util import rand_fp, RLC
 
 
 TESTING_DATA = ((Opcode.JUMP, bytes([7])),)
@@ -20,19 +19,19 @@ TESTING_DATA = ((Opcode.JUMP, bytes([7])),)
 
 @pytest.mark.parametrize("opcode, dest_bytes", TESTING_DATA)
 def test_jump(opcode: Opcode, dest_bytes: bytes):
-    rlc_store = RLCStore()
-    dest = rlc_store.to_rlc(bytes(reversed(dest_bytes)))
+    randomness = rand_fp()
+    dest = RLC(bytes(reversed(dest_bytes)), randomness)
 
     block = Block()
     # Jumps to PC=7
     # PUSH1 80 PUSH1 40 PUSH1 07 JUMP JUMPDEST STOP
-    bytecode = Bytecode(f"6080604060{dest_bytes.hex()}565b00")
-    bytecode_hash = rlc_store.to_rlc(bytecode.hash, 32)
+    bytecode = Bytecode().push1(0x80).push1(0x40).push1(dest_bytes).jump().jumpdest().stop()
+    bytecode_hash = RLC(bytecode.hash(), randomness)
 
     tables = Tables(
-        block_table=set(block.table_assignments(rlc_store)),
+        block_table=set(block.table_assignments(randomness)),
         tx_table=set(),
-        bytecode_table=set(bytecode.table_assignments(rlc_store)),
+        bytecode_table=set(bytecode.table_assignments(randomness)),
         rw_table=set(
             [
                 (9, RW.Read, RWTableTag.Stack, 1, 1021, dest, 0, 0),
@@ -41,7 +40,7 @@ def test_jump(opcode: Opcode, dest_bytes: bytes):
     )
 
     verify_steps(
-        rlc_store=rlc_store,
+        randomness=randomness,
         tables=tables,
         steps=[
             StepState(
@@ -50,7 +49,7 @@ def test_jump(opcode: Opcode, dest_bytes: bytes):
                 call_id=1,
                 is_root=True,
                 is_create=False,
-                opcode_source=bytecode_hash,
+                code_source=bytecode_hash,
                 program_counter=6,
                 stack_pointer=1021,
                 gas_left=8,
@@ -61,7 +60,7 @@ def test_jump(opcode: Opcode, dest_bytes: bytes):
                 call_id=1,
                 is_root=True,
                 is_create=False,
-                opcode_source=bytecode_hash,
+                code_source=bytecode_hash,
                 program_counter=int.from_bytes(dest_bytes, "little"),
                 stack_pointer=1022,
                 gas_left=0,

--- a/tests/evm/test_jumpi.py
+++ b/tests/evm/test_jumpi.py
@@ -1,6 +1,5 @@
 import pytest
 
-from typing import Optional
 from zkevm_specs.evm import (
     ExecutionState,
     StepState,
@@ -12,7 +11,7 @@ from zkevm_specs.evm import (
     Block,
     Bytecode,
 )
-from zkevm_specs.util import hex_to_word, rand_bytes, RLCStore
+from zkevm_specs.util import rand_fp, RLC
 
 
 TESTING_DATA = ((Opcode.JUMPI, bytes([40]), bytes([7])),)
@@ -20,20 +19,20 @@ TESTING_DATA = ((Opcode.JUMPI, bytes([40]), bytes([7])),)
 
 @pytest.mark.parametrize("opcode, cond_bytes, dest_bytes", TESTING_DATA)
 def test_jumpi_cond_nonzero(opcode: Opcode, cond_bytes: bytes, dest_bytes: bytes):
-    rlc_store = RLCStore()
-    cond = rlc_store.to_rlc(bytes(reversed(cond_bytes)))
-    dest = rlc_store.to_rlc(bytes(reversed(dest_bytes)))
+    randomness = rand_fp()
+    cond = RLC(bytes(reversed(cond_bytes)), randomness)
+    dest = RLC(bytes(reversed(dest_bytes)), randomness)
 
     block = Block()
     # Jumps to PC=7 because the condition (40) is nonzero.
     # PUSH1 80 PUSH1 40 PUSH1 07 JUMPI JUMPDEST STOP
-    bytecode = Bytecode(f"6080604060{dest_bytes.hex()}575b00")
-    bytecode_hash = rlc_store.to_rlc(bytecode.hash, 32)
+    bytecode = Bytecode().push1(0x80).push1(0x40).push1(dest_bytes).jumpi().jumpdest().stop()
+    bytecode_hash = RLC(bytecode.hash(), randomness)
 
     tables = Tables(
-        block_table=set(block.table_assignments(rlc_store)),
+        block_table=set(block.table_assignments(randomness)),
         tx_table=set(),
-        bytecode_table=set(bytecode.table_assignments(rlc_store)),
+        bytecode_table=set(bytecode.table_assignments(randomness)),
         rw_table=set(
             [
                 (9, RW.Read, RWTableTag.Stack, 1, 1021, dest, 0, 0),
@@ -43,7 +42,7 @@ def test_jumpi_cond_nonzero(opcode: Opcode, cond_bytes: bytes, dest_bytes: bytes
     )
 
     verify_steps(
-        rlc_store=rlc_store,
+        randomness=randomness,
         tables=tables,
         steps=[
             StepState(
@@ -52,7 +51,7 @@ def test_jumpi_cond_nonzero(opcode: Opcode, cond_bytes: bytes, dest_bytes: bytes
                 call_id=1,
                 is_root=True,
                 is_create=False,
-                opcode_source=bytecode_hash,
+                code_source=bytecode_hash,
                 program_counter=6,
                 stack_pointer=1021,
                 gas_left=10,
@@ -63,7 +62,7 @@ def test_jumpi_cond_nonzero(opcode: Opcode, cond_bytes: bytes, dest_bytes: bytes
                 call_id=1,
                 is_root=True,
                 is_create=False,
-                opcode_source=bytecode_hash,
+                code_source=bytecode_hash,
                 program_counter=int.from_bytes(dest_bytes, "little"),
                 stack_pointer=1023,
                 gas_left=0,
@@ -77,20 +76,20 @@ TESTING_DATA_ZERO_COND = ((Opcode.JUMPI, bytes([0]), bytes([8])),)
 
 @pytest.mark.parametrize("opcode, cond_bytes, dest_bytes", TESTING_DATA_ZERO_COND)
 def test_jumpi_cond_zero(opcode: Opcode, cond_bytes: bytes, dest_bytes: bytes):
-    rlc_store = RLCStore()
-    cond = rlc_store.to_rlc(bytes(reversed(cond_bytes)))
-    dest = rlc_store.to_rlc(bytes(reversed(dest_bytes)))
+    randomness = rand_fp()
+    cond = RLC(bytes(reversed(cond_bytes)), randomness)
+    dest = RLC(bytes(reversed(dest_bytes)), randomness)
 
     block = Block()
     # Jumps to PC=7 because the condition (0) is zero.
     # PUSH1 80 PUSH1 0 PUSH1 08 JUMPI STOP
-    bytecode = Bytecode(f"6080600060{dest_bytes.hex()}575b00")
-    bytecode_hash = rlc_store.to_rlc(bytecode.hash, 32)
+    bytecode = Bytecode().push1(0x80).push1(cond_bytes).push1(dest_bytes).jumpi().stop()
+    bytecode_hash = RLC(bytecode.hash(), randomness)
 
     tables = Tables(
-        block_table=set(block.table_assignments(rlc_store)),
+        block_table=set(block.table_assignments(randomness)),
         tx_table=set(),
-        bytecode_table=set(bytecode.table_assignments(rlc_store)),
+        bytecode_table=set(bytecode.table_assignments(randomness)),
         rw_table=set(
             [
                 (9, RW.Read, RWTableTag.Stack, 1, 1021, dest, 0, 0),
@@ -100,7 +99,7 @@ def test_jumpi_cond_zero(opcode: Opcode, cond_bytes: bytes, dest_bytes: bytes):
     )
 
     verify_steps(
-        rlc_store=rlc_store,
+        randomness=randomness,
         tables=tables,
         steps=[
             StepState(
@@ -109,7 +108,7 @@ def test_jumpi_cond_zero(opcode: Opcode, cond_bytes: bytes, dest_bytes: bytes):
                 call_id=1,
                 is_root=True,
                 is_create=False,
-                opcode_source=bytecode_hash,
+                code_source=bytecode_hash,
                 program_counter=6,
                 stack_pointer=1021,
                 gas_left=10,
@@ -120,7 +119,7 @@ def test_jumpi_cond_zero(opcode: Opcode, cond_bytes: bytes, dest_bytes: bytes):
                 call_id=1,
                 is_root=True,
                 is_create=False,
-                opcode_source=bytecode_hash,
+                code_source=bytecode_hash,
                 program_counter=7,
                 stack_pointer=1023,
                 gas_left=0,

--- a/tests/evm/test_push.py
+++ b/tests/evm/test_push.py
@@ -3,7 +3,6 @@ import pytest
 from zkevm_specs.evm import (
     ExecutionState,
     StepState,
-    Opcode,
     verify_steps,
     Tables,
     RWTableTag,
@@ -11,34 +10,33 @@ from zkevm_specs.evm import (
     Block,
     Bytecode,
 )
-from zkevm_specs.util import rand_bytes, RLCStore
+from zkevm_specs.util import rand_bytes, rand_fp, RLC
 
 
 TESTING_DATA = tuple(
     [
-        (Opcode.PUSH1, bytes([1])),
-        (Opcode.PUSH2, bytes([2, 1])),
-        (Opcode.PUSH31, bytes([i for i in range(31, 0, -1)])),
-        (Opcode.PUSH32, bytes([i for i in range(32, 0, -1)])),
+        (bytes([1])),
+        (bytes([2, 1])),
+        (bytes([i for i in range(31, 0, -1)])),
+        (bytes([i for i in range(32, 0, -1)])),
     ]
-    + [(Opcode(Opcode.PUSH1 + i), rand_bytes(i + 1)) for i in range(32)]
+    + [(rand_bytes(i + 1)) for i in range(32)]
 )
 
 
-@pytest.mark.parametrize("opcode, value_be_bytes", TESTING_DATA)
-def test_push(opcode: Opcode, value_be_bytes: bytes):
-    rlc_store = RLCStore()
+@pytest.mark.parametrize("value_be_bytes", TESTING_DATA)
+def test_push(value_be_bytes: bytes):
+    randomness = rand_fp()
 
-    value = rlc_store.to_rlc(bytes(reversed(value_be_bytes)))
+    value = RLC(bytes(reversed(value_be_bytes)), randomness)
 
-    block = Block()
-    bytecode = Bytecode(f"{opcode.hex()}{value_be_bytes.hex()}00")
-    bytecode_hash = rlc_store.to_rlc(bytecode.hash, 32)
+    bytecode = Bytecode().push(value_be_bytes, n_bytes=len(value_be_bytes))
+    bytecode_hash = RLC(bytecode.hash(), randomness)
 
     tables = Tables(
-        block_table=set(block.table_assignments(rlc_store)),
+        block_table=set(Block().table_assignments(randomness)),
         tx_table=set(),
-        bytecode_table=set(bytecode.table_assignments(rlc_store)),
+        bytecode_table=set(bytecode.table_assignments(randomness)),
         rw_table=set(
             [
                 (8, RW.Write, RWTableTag.Stack, 1, 1023, value, 0, 0),
@@ -47,7 +45,7 @@ def test_push(opcode: Opcode, value_be_bytes: bytes):
     )
 
     verify_steps(
-        rlc_store=rlc_store,
+        randomness=randomness,
         tables=tables,
         steps=[
             StepState(
@@ -56,7 +54,7 @@ def test_push(opcode: Opcode, value_be_bytes: bytes):
                 call_id=1,
                 is_root=True,
                 is_create=False,
-                opcode_source=bytecode_hash,
+                code_source=bytecode_hash,
                 program_counter=0,
                 stack_pointer=1024,
                 gas_left=3,
@@ -67,7 +65,7 @@ def test_push(opcode: Opcode, value_be_bytes: bytes):
                 call_id=1,
                 is_root=True,
                 is_create=False,
-                opcode_source=bytecode_hash,
+                code_source=bytecode_hash,
                 program_counter=1 + len(value_be_bytes),
                 stack_pointer=1023,
                 gas_left=0,

--- a/tests/test_bytecode_circuit.py
+++ b/tests/test_bytecode_circuit.py
@@ -3,22 +3,22 @@ from zkevm_specs.bytecode import *
 import traceback
 from copy import deepcopy
 from zkevm_specs.evm import Bytecode
-from zkevm_specs.util import RLCStore
+from zkevm_specs.util import RLC, rand_fp
 
 # Unroll the bytecode
-def unroll(bytecode, rlc_store):
-    return UnrolledBytecode(bytecode, list(Bytecode(bytecode).table_assignments(rlc_store)))
+def unroll(bytecode, randomness):
+    return UnrolledBytecode(bytecode, list(Bytecode(bytecode).table_assignments(randomness)))
 
 
 # Verify the bytecode circuit with the given data
-def verify(k, bytecodes, rlc_store, success):
+def verify(k, bytecodes, randomness, success):
     push_table = assign_push_table()
-    keccak_table = assign_keccak_table(map(lambda v: v.bytes, bytecodes), rlc_store)
-    rows = assign_bytecode_circuit(k, bytecodes, rlc_store)
+    keccak_table = assign_keccak_table(map(lambda v: v.bytes, bytecodes), randomness)
+    rows = assign_bytecode_circuit(k, bytecodes, randomness)
     try:
         for (idx, row) in enumerate(rows):
             prev_row = rows[(idx - 1) % len(rows)]
-            check_bytecode_row(row, prev_row, push_table, keccak_table, rlc_store.randomness)
+            check_bytecode_row(row, prev_row, push_table, keccak_table, randomness)
             ok = True
     except AssertionError as e:
         if success:
@@ -28,7 +28,7 @@ def verify(k, bytecodes, rlc_store, success):
 
 
 k = 10
-rlc_store = RLCStore()
+randomness = rand_fp()
 
 
 def test_bytecode_unrolling():
@@ -48,110 +48,104 @@ def test_bytecode_unrolling():
         for _ in range(n):
             rows.append((0, len(rows), data_byte, False))
     # Set the hash of the complete bytecode in the rows
-    hash = rlc_store.to_rlc(keccak256(bytes(bytecode)), 32)
+    hash = RLC(bytes(reversed(keccak256(bytes(bytecode)))), randomness)
     for i in range(len(rows)):
         rows[i] = (hash, rows[i][1], rows[i][2], rows[i][3])
     # Unroll the bytecode
-    unrolled = unroll(bytes(bytecode), rlc_store)
+    unrolled = unroll(bytes(bytecode), randomness)
     # Check if the bytecode was unrolled correctly
     assert UnrolledBytecode(bytes(bytecode), rows) == unrolled
     # Verify the unrolling in the circuit
-    verify(k, [unrolled], rlc_store, True)
+    verify(k, [unrolled], randomness, True)
 
 
 def test_bytecode_empty():
-    bytecodes = [
-        unroll(bytes([]), rlc_store),
-    ]
-    verify(k, bytecodes, rlc_store, True)
+    bytecodes = [unroll(bytes([]), randomness)]
+    verify(k, bytecodes, randomness, True)
 
 
 def test_bytecode_full():
-    bytecodes = [
-        unroll(bytes([7] * 2 ** k), rlc_store),
-    ]
-    verify(k, bytecodes, rlc_store, True)
+    bytecodes = [unroll(bytes([7] * 2 ** k), randomness)]
+    verify(k, bytecodes, randomness, True)
 
 
 def test_bytecode_incomplete():
-    bytecodes = [
-        unroll(bytes([7] * (2 ** k + 1)), rlc_store),
-    ]
-    verify(k, bytecodes, rlc_store, False)
+    bytecodes = [unroll(bytes([7] * (2 ** k + 1)), randomness)]
+    verify(k, bytecodes, randomness, False)
 
 
 def test_bytecode_multiple():
     bytecodes = [
-        unroll(bytes([]), rlc_store),
-        unroll(bytes([Opcode.PUSH32]), rlc_store),
-        unroll(bytes([Opcode.PUSH32, Opcode.ADD]), rlc_store),
-        unroll(bytes([Opcode.ADD, Opcode.PUSH32]), rlc_store),
-        unroll(bytes([Opcode.ADD, Opcode.PUSH32, Opcode.ADD]), rlc_store),
+        unroll(bytes([]), randomness),
+        unroll(bytes([Opcode.PUSH32]), randomness),
+        unroll(bytes([Opcode.PUSH32, Opcode.ADD]), randomness),
+        unroll(bytes([Opcode.ADD, Opcode.PUSH32]), randomness),
+        unroll(bytes([Opcode.ADD, Opcode.PUSH32, Opcode.ADD]), randomness),
     ]
-    verify(k, bytecodes, rlc_store, True)
+    verify(k, bytecodes, randomness, True)
 
 
 def test_bytecode_invalid_hash_data():
-    unrolled = unroll(bytes([8, 2, 3, 8, 9, 7, 128]), rlc_store)
-    verify(k, [unrolled], rlc_store, True)
+    unrolled = unroll(bytes([8, 2, 3, 8, 9, 7, 128]), randomness)
+    verify(k, [unrolled], randomness, True)
 
     # Change the hash on the first position
     invalid = deepcopy(unrolled)
     row = unrolled.rows[0]
-    invalid.rows[0] = (row[0] + 1, row[1], row[2], row[3])
-    verify(k, [invalid], rlc_store, False)
+    invalid.rows[0] = (row[0].value + 1, row[1], row[2], row[3])
+    verify(k, [invalid], randomness, False)
 
     # Change the hash on another position
     invalid = deepcopy(unrolled)
     row = unrolled.rows[4]
-    invalid.rows[0] = (row[0] + 1, row[1], row[2], row[3])
-    verify(k, [invalid], rlc_store, False)
+    invalid.rows[0] = (row[0].value + 1, row[1], row[2], row[3])
+    verify(k, [invalid], randomness, False)
 
     # Change all the hashes so it doesn't match the keccak lookup hash
     invalid = deepcopy(unrolled)
     for idx, row in enumerate(unrolled.rows):
         invalid.rows[idx] = (1, row[1], row[2], row[3])
-    verify(k, [invalid], rlc_store, False)
+    verify(k, [invalid], randomness, False)
 
 
 def test_bytecode_invalid_index():
-    unrolled = unroll(bytes([8, 2, 3, 8, 9, 7, 128]), rlc_store)
-    verify(k, [unrolled], rlc_store, True)
+    unrolled = unroll(bytes([8, 2, 3, 8, 9, 7, 128]), randomness)
+    verify(k, [unrolled], randomness, True)
 
     # Start the index at 1
     invalid = deepcopy(unrolled)
     for idx, row in enumerate(unrolled.rows):
-        invalid.rows[idx] = (row[0] + 1, row[1], row[2], row[3])
-    verify(k, [invalid], rlc_store, False)
+        invalid.rows[idx] = (row[0].value + 1, row[1], row[2], row[3])
+    verify(k, [invalid], randomness, False)
 
     # Don't increment an index once
     invalid = deepcopy(unrolled)
     row = unrolled.rows[-1]
-    invalid.rows[-1] = (row[0] - 1, row[1], row[2], row[3])
-    verify(k, [invalid], rlc_store, False)
+    invalid.rows[-1] = (row[0].value - 1, row[1], row[2], row[3])
+    verify(k, [invalid], randomness, False)
 
 
 def test_bytecode_invalid_byte_data():
-    unrolled = unroll(bytes([8, 2, 3, 8, 9, 7, 128]), rlc_store)
-    verify(k, [unrolled], rlc_store, True)
+    unrolled = unroll(bytes([8, 2, 3, 8, 9, 7, 128]), randomness)
+    verify(k, [unrolled], randomness, True)
 
     # Change the first byte
     invalid = deepcopy(unrolled)
     row = unrolled.rows[0]
     invalid.rows[0] = (row[0], row[1], row[2], 9)
-    verify(k, [invalid], rlc_store, False)
+    verify(k, [invalid], randomness, False)
 
     # Change a byte on another position
     invalid = deepcopy(unrolled)
     row = unrolled.rows[5]
     invalid.rows[5] = (row[0], row[1], row[2], 6)
-    verify(k, [invalid], rlc_store, False)
+    verify(k, [invalid], randomness, False)
 
     # Set a byte value out of range
     invalid = deepcopy(unrolled)
     row = unrolled.rows[3]
     invalid.rows[3] = (row[0], row[1], row[2], 256)
-    verify(k, [invalid], rlc_store, False)
+    verify(k, [invalid], randomness, False)
 
 
 def test_bytecode_invalid_is_code():
@@ -167,24 +161,24 @@ def test_bytecode_invalid_is_code():
                 Opcode.PUSH6,
             ]
         ),
-        rlc_store,
+        randomness,
     )
-    verify(k, [unrolled], rlc_store, True)
+    verify(k, [unrolled], randomness, True)
 
     # Mark the 3rd byte as code (is push data from the first PUSH1)
     invalid = deepcopy(unrolled)
     row = unrolled.rows[2]
     invalid.rows[2] = (row[0], row[1], 1, row[3])
-    verify(k, [invalid], rlc_store, False)
+    verify(k, [invalid], randomness, False)
 
     # Mark the 4rd byte as data (is code)
     invalid = deepcopy(unrolled)
     row = unrolled.rows[3]
     invalid.rows[3] = (row[0], row[1], 0, row[3])
-    verify(k, [invalid], rlc_store, False)
+    verify(k, [invalid], randomness, False)
 
     # Mark the 7th byte as code (is data for the PUSH7)
     invalid = deepcopy(unrolled)
     row = unrolled.rows[6]
     invalid.rows[6] = (row[0], row[1], 1, row[3])
-    verify(k, [invalid], rlc_store, False)
+    verify(k, [invalid], randomness, False)


### PR DESCRIPTION
This PR aims to spec `ExecutionState::EndTx` and `ExecutionState::EndBlock`, for enable EVM circuit to verify block consists of minimal transaction. With `BeginTx`, `EndTx` and `EndBlock`, the finite state machine diagram will look like:

![fsm-check-code-hash](https://user-images.githubusercontent.com/24424538/149205826-dd57a24c-e222-47bd-9ea0-2428f524ad3d.png)

The `EndTx` aims to handle tx refund to signer, and tx fee to coinbase.

The `EndBlock` aims to pad the EVM circuit to the fixed capacity, and checks `tx_id` and `rw_counter` at the last step.

Also it refactors random linear combination usage, to make things more straightforward. Regardless of the refactors, please refer to [`end_tx.py`](https://github.com/appliedzkp/zkevm-specs/pull/88/files#diff-44571e5b672453888706ef38908a3c9afbf537bd9e47aadc3045a3816f5b4524) and [`end_block.py`](https://github.com/appliedzkp/zkevm-specs/pull/88/files#diff-aa44b9213476adde5c03ae2a3921372dd2eda9faf199b67e5d4e2ce875e34842) for spec itself.


## TODO

- [x] Testing `ExecutionState::EndTx`
- [x] Testing `ExecutionState::EndBlock`
