### PR TITLE
Untrack `last_callee_*` of `StepState`

### DIFF
--- a/src/zkevm_specs/evm/execution/begin_tx.py
+++ b/src/zkevm_specs/evm/execution/begin_tx.py
@@ -80,11 +80,14 @@ def begin_tx(instruction: Instruction):
             (CallContextFieldTag.CallDataLength, tx_call_data_length),
             (CallContextFieldTag.Value, tx_value),
             (CallContextFieldTag.IsStatic, False),
+            (CallContextFieldTag.LastCalleeId, 0),
+            (CallContextFieldTag.LastCalleeReturnDataOffset, 0),
+            (CallContextFieldTag.LastCalleeReturnDataLength, 0),
         ]:
             instruction.constrain_equal(instruction.call_context_lookup(tag, call_id=call_id), value)
 
         instruction.step_state_transition_to_new_context(
-            rw_counter=Transition.delta(16),
+            rw_counter=Transition.delta(19),
             call_id=Transition.to(call_id),
             is_root=Transition.to(True),
             is_create=Transition.to(False),

--- a/src/zkevm_specs/evm/instruction.py
+++ b/src/zkevm_specs/evm/instruction.py
@@ -113,9 +113,6 @@ class Instruction:
                 "gas_left",
                 "memory_size",
                 "state_write_counter",
-                "last_callee_id",
-                "last_callee_return_data_offset",
-                "last_callee_return_data_length",
             ]
         )
 
@@ -160,9 +157,6 @@ class Instruction:
             program_counter=Transition.to(0),
             stack_pointer=Transition.to(1024),
             memory_size=Transition.to(0),
-            last_callee_id=Transition.to(0),
-            last_callee_return_data_offset=Transition.to(0),
-            last_callee_return_data_length=Transition.to(0),
         )
 
     def step_state_transition_in_same_context(
@@ -192,9 +186,6 @@ class Instruction:
             is_root=Transition.same(),
             is_create=Transition.same(),
             code_source=Transition.same(),
-            last_callee_id=Transition.same(),
-            last_callee_return_data_offset=Transition.same(),
-            last_callee_return_data_length=Transition.same(),
         )
 
     def sum(self, values: Sequence[int]) -> int:

--- a/src/zkevm_specs/evm/step.py
+++ b/src/zkevm_specs/evm/step.py
@@ -37,9 +37,6 @@ class StepState:
     # not often used.
     memory_size: int
     state_write_counter: int
-    last_callee_id: int
-    last_callee_return_data_offset: int
-    last_callee_return_data_length: int
 
     def __init__(
         self,
@@ -54,9 +51,6 @@ class StepState:
         gas_left: int = 0,
         memory_size: int = 0,
         state_write_counter: int = 0,
-        last_callee_id: int = 0,
-        last_callee_return_data_offset: int = 0,
-        last_callee_return_data_length: int = 0,
     ) -> None:
         self.execution_state = execution_state
         self.rw_counter = rw_counter
@@ -69,6 +63,3 @@ class StepState:
         self.gas_left = gas_left
         self.memory_size = memory_size
         self.state_write_counter = state_write_counter
-        self.last_callee_id = last_callee_id
-        self.last_callee_return_data_offset = last_callee_return_data_offset
-        self.last_callee_return_data_length = last_callee_return_data_length

--- a/tests/evm/test_begin_tx.py
+++ b/tests/evm/test_begin_tx.py
@@ -212,6 +212,9 @@ def test_begin_tx(tx: Transaction, callee: Account, result: bool):
                     0,
                 ),
                 (16, RW.Read, RWTableTag.CallContext, 1, CallContextFieldTag.IsStatic, 0, 0, 0, 0, 0),
+                (17, RW.Read, RWTableTag.CallContext, 1, CallContextFieldTag.LastCalleeId, 0, 0, 0, 0, 0),
+                (18, RW.Read, RWTableTag.CallContext, 1, CallContextFieldTag.LastCalleeReturnDataOffset, 0, 0, 0, 0, 0),
+                (19, RW.Read, RWTableTag.CallContext, 1, CallContextFieldTag.LastCalleeReturnDataLength, 0, 0, 0, 0, 0),
             ]
             + (
                 []
@@ -256,7 +259,7 @@ def test_begin_tx(tx: Transaction, callee: Account, result: bool):
             ),
             StepState(
                 execution_state=ExecutionState.EndTx if callee.code_hash() == EMPTY_CODE_HASH else ExecutionState.PUSH,
-                rw_counter=17,
+                rw_counter=20,
                 call_id=1,
                 is_root=True,
                 is_create=False,


### PR DESCRIPTION
This PR is once part of #82, and aims to move the tracking of `last_callee_*` to `rw_table` for simplicity.