### PR TITLE
Change field value from int to field numbers

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ packages = find:
 python_requires = >=3.6
 install_requires =
     pycryptodome==3.11.0
+    py-ecc==6.0.0
 
 [options.packages.find]
 where = src

--- a/src/zkevm_specs/bytecode.py
+++ b/src/zkevm_specs/bytecode.py
@@ -1,6 +1,6 @@
 from typing import Sequence, Union, Tuple, Set
 from collections import namedtuple
-from .util import keccak256, fp_add, fp_mul, RLC
+from .util import keccak256, FpNum, RLC
 from .evm.opcode import get_push_size
 from .encoding import U8, U256, is_circuit_code
 
@@ -31,6 +31,7 @@ def select(
 def check_bytecode_row(
     row: Row, prev_row: Row, push_table: Set[Tuple[int, int]], keccak_table: Set[Tuple[int, int, int]], r: int
 ):
+    row = Row([FpNum(v) for v in row])
     if not row.q_first and not prev_row.is_final:
         # Continue
         # index needs to increase by 1
@@ -38,7 +39,7 @@ def check_bytecode_row(
         # is_code := push_data_left_prev == 0
         assert row.is_code == (prev_row.push_data_left == 0)
         # hash_rlc := hash_rlc_prev * r + byte
-        assert row.hash_rlc == fp_add(fp_mul(prev_row.hash_rlc, r), row.byte)
+        assert row.hash_rlc == prev_row.hash_rlc * r + row.byte
 
         # padding needs to remain the same
         assert row.padding == prev_row.padding

--- a/src/zkevm_specs/bytecode.py
+++ b/src/zkevm_specs/bytecode.py
@@ -1,6 +1,6 @@
 from typing import Sequence, Union, Tuple, Set
 from collections import namedtuple
-from .util import keccak256, FpNum, RLC
+from .util import keccak256, FQ, RLC
 from .evm.opcode import get_push_size
 from .encoding import U8, U256, is_circuit_code
 
@@ -31,8 +31,9 @@ def select(
 def check_bytecode_row(
     row: Row, prev_row: Row, push_table: Set[Tuple[int, int]], keccak_table: Set[Tuple[int, int, int]], r: int
 ):
-    row = Row([FpNum(v) for v in row])
-    if not row.q_first and not prev_row.is_final:
+    row = Row(*[v if isinstance(v, RLC) else FQ(v) for v in row])
+    prev_row = Row(*[v if isinstance(v, RLC) else FQ(v) for v in prev_row])
+    if row.q_first == 0 and prev_row.is_final == 0:
         # Continue
         # index needs to increase by 1
         assert row.index == prev_row.index + 1
@@ -64,7 +65,7 @@ def check_bytecode_row(
     assert row.push_data_left == select(row.is_code, row.byte_push_size, prev_row.push_data_left - 1)
 
     # Padding
-    if not row.q_first:
+    if row.q_first == 0:
         # padding can only go 0 -> 1 once
         assert_bool(row.padding - prev_row.padding)
 
@@ -73,17 +74,17 @@ def check_bytecode_row(
     # we accumulated all the bytes. We also have to go through the bytes
     # in a forward manner because that's the only way we can know which
     # bytes are op codes and which are push data.
-    if row.q_last:
+    if row.q_last == 1:
         # padding needs to be enabled OR
         # the last row needs to be the last byte
-        assert row.padding or row.is_final
+        assert row.padding == 1 or row.is_final == 1
 
     # Lookup how many bytes the current opcode pushes
     # (also indirectly range checks `byte` to be in [0, 255])
     assert (row.byte, row.byte_push_size) in push_table
 
     # keccak lookup when on the last byte
-    if row.is_final and not row.padding:
+    if row.is_final == 1 and row.padding == 0:
         assert (row.hash_rlc, row.hash_length, row.hash) in keccak_table
 
 
@@ -96,7 +97,7 @@ def assign_bytecode_circuit(k: int, bytecodes: Sequence[UnrolledBytecode], rando
     offset = 0
     for bytecode in bytecodes:
         push_data_left = 0
-        hash_rlc = 0
+        hash_rlc = FQ(0)
         for idx, row in enumerate(bytecode.rows):
             # Track which byte is an opcode and which is push data
             is_code = push_data_left == 0
@@ -104,7 +105,7 @@ def assign_bytecode_circuit(k: int, bytecodes: Sequence[UnrolledBytecode], rando
             push_data_left = byte_push_size if is_code else push_data_left - 1
 
             # Add the byte to the accumulator
-            hash_rlc = fp_add(fp_mul(hash_rlc, randomness), row[2])
+            hash_rlc = hash_rlc * randomness + row[2]
 
             # Set the data for this row
             rows.append(
@@ -151,6 +152,14 @@ def assign_bytecode_circuit(k: int, bytecodes: Sequence[UnrolledBytecode], rando
     return rows
 
 
+# Convert the elements in the table to be either RLC or FQ
+def _convert_table(table):
+    converted = []
+    for row in table:
+        converted.append(tuple([v if isinstance(v, RLC) else FQ(v) for v in row]))
+    return converted
+
+
 # Generate the push table: BYTE -> NUM_PUSHED:
 # [0, OpcodeId::PUSH1[ -> 0
 # [OpcodeId::PUSH1, OpcodeId::PUSH32] -> [1..32]
@@ -159,7 +168,7 @@ def assign_push_table():
     push_table = []
     for i in range(256):
         push_table.append((i, get_push_size(i)))
-    return push_table
+    return _convert_table(push_table)
 
 
 # Generate keccak table
@@ -169,4 +178,4 @@ def assign_keccak_table(bytecodes: Sequence[bytes], randomness: int):
         hash = RLC(bytes(reversed(keccak256(bytecode))), randomness)
         rlc = RLC(bytes(reversed(bytecode)), randomness, len(bytecode))
         keccak_table.append((rlc, len(bytecode), hash))
-    return keccak_table
+    return _convert_table(keccak_table)

--- a/src/zkevm_specs/evm/execution/begin_tx.py
+++ b/src/zkevm_specs/evm/execution/begin_tx.py
@@ -39,7 +39,7 @@ def begin_tx(instruction: Instruction):
 
     # TODO: Handle gas cost of tx level access list (EIP 2930)
     tx_call_data_gas_cost = instruction.tx_context_lookup(tx_id, TxContextFieldTag.CallDataGasCost)
-    gas_left = tx_gas - (GAS_COST_CREATION_TX if tx_is_create else GAS_COST_TX) - tx_call_data_gas_cost
+    gas_left = tx_gas - (GAS_COST_CREATION_TX if tx_is_create == 1 else GAS_COST_TX) - tx_call_data_gas_cost
     instruction.constrain_gas_left_not_underflow(gas_left)
 
     # Prepare access list of caller and callee
@@ -56,7 +56,7 @@ def begin_tx(instruction: Instruction):
         rw_counter_end_of_reversion,
     )
 
-    if tx_is_create:
+    if tx_is_create == 1:
         # TODO: Verify created address
         # TODO: Decide what code_source should be (tx_id or hash of creation code)
         raise NotImplementedError

--- a/src/zkevm_specs/evm/execution/slt_sgt.py
+++ b/src/zkevm_specs/evm/execution/slt_sgt.py
@@ -22,11 +22,12 @@ def scmp(instruction: Instruction):
     b8s = instruction.rlc_to_le_bytes(bb)
     c8s = instruction.rlc_to_le_bytes(c)
 
-    a_lo = int.from_bytes(a8s[:16], "little")
-    a_hi = int.from_bytes(a8s[16:], "little")
-    b_lo = int.from_bytes(b8s[:16], "little")
-    b_hi = int.from_bytes(b8s[16:], "little")
-    cc = int.from_bytes(c8s, "little")
+    a_lo = instruction.bytes_to_fq(a8s[:16])
+    a_hi = instruction.bytes_to_fq(a8s[16:])
+    b_lo = instruction.bytes_to_fq(b8s[:16])
+    b_hi = instruction.bytes_to_fq(b8s[16:])
+    assert c8s[31] == 0
+    cc = instruction.bytes_to_fq(c8s[:31])
 
     a_lt_b_lo, a_eq_b_lo = instruction.compare(a_lo, b_lo, 16)
     a_lt_b_hi, a_eq_b_hi = instruction.compare(a_hi, b_hi, 16)

--- a/src/zkevm_specs/evm/instruction.py
+++ b/src/zkevm_specs/evm/instruction.py
@@ -290,11 +290,11 @@ class Instruction:
     def int_to_rlc(self, value: int, n_bytes: int) -> RLC:
         return RLC(value, self.randomness, n_bytes)
 
-    def bytes_to_int(self, value: Sequence[int]) -> int:
+    def bytes_to_int(self, value: bytes) -> int:
         assert len(value) <= MAX_N_BYTES, "Too many bytes to composite an integer in field"
         return int.from_bytes(value, "little")
 
-    def bytes_to_fq(self, value: Sequence[int]) -> FQ:
+    def bytes_to_fq(self, value: bytes) -> FQ:
         assert len(value) <= MAX_N_BYTES, "Too many bytes to composite an integer in field"
         return FQ(int.from_bytes(value, "little"))
 

--- a/src/zkevm_specs/evm/instruction.py
+++ b/src/zkevm_specs/evm/instruction.py
@@ -221,8 +221,8 @@ class Instruction:
 
     def compare(self, lhs: FQ, rhs: FQ, n_bytes: int) -> Tuple[bool, bool]:
         assert n_bytes <= MAX_N_BYTES, "Too many bytes to composite an integer in field"
-        assert lhs.n < 256 ** n_bytes, f"lhs {lhs} exceeds the range of {n_bytes} bytes"
-        assert rhs.n < 256 ** n_bytes, f"rhs {rhs} exceeds the range of {n_bytes} bytes"
+        assert lhs.n < 256**n_bytes, f"lhs {lhs} exceeds the range of {n_bytes} bytes"
+        assert rhs.n < 256**n_bytes, f"rhs {rhs} exceeds the range of {n_bytes} bytes"
 
         return lhs.n < rhs.n, lhs.n == rhs.n
 

--- a/src/zkevm_specs/evm/step.py
+++ b/src/zkevm_specs/evm/step.py
@@ -1,4 +1,6 @@
+from typing import Any, Sequence
 from .execution_state import ExecutionState
+from ..util import FpNum, RLC
 
 
 class StepState:
@@ -46,20 +48,20 @@ class StepState:
         is_root: bool = False,
         is_create: bool = False,
         code_source: int = 0,
-        program_counter: int = 0,
+        program_counter: FpNum = FpNum(0),
         stack_pointer: int = 1024,
         gas_left: int = 0,
         memory_size: int = 0,
         state_write_counter: int = 0,
     ) -> None:
         self.execution_state = execution_state
-        self.rw_counter = rw_counter
-        self.call_id = call_id
+        self.rw_counter = FpNum(rw_counter)
+        self.call_id = FpNum(call_id)
         self.is_root = is_root
         self.is_create = is_create
         self.code_source = code_source
-        self.program_counter = program_counter
-        self.stack_pointer = stack_pointer
-        self.gas_left = gas_left
-        self.memory_size = memory_size
-        self.state_write_counter = state_write_counter
+        self.program_counter = FpNum(program_counter)
+        self.stack_pointer = FpNum(stack_pointer)
+        self.gas_left = FpNum(gas_left)
+        self.memory_size = FpNum(memory_size)
+        self.state_write_counter = FpNum(state_write_counter)

--- a/src/zkevm_specs/evm/step.py
+++ b/src/zkevm_specs/evm/step.py
@@ -14,8 +14,8 @@ class StepState:
     """
 
     execution_state: ExecutionState
-    rw_counter: int
-    call_id: int
+    rw_counter: FpNum
+    call_id: FpNum
 
     # The following 3 fields decide the opcode source. There are 2 possible
     # cases:
@@ -28,17 +28,17 @@ class StepState:
     #   We set code_source to bytecode_hash and lookup bytecode_table.
     is_root: bool
     is_create: bool
-    code_source: int
+    code_source: RLC
 
     # The following fields change almost every step.
-    program_counter: int
-    stack_pointer: int
-    gas_left: int
+    program_counter: FpNum
+    stack_pointer: FpNum
+    gas_left: FpNum
 
     # The following fields could be further moved into rw_table if we find them
     # not often used.
-    memory_size: int
-    state_write_counter: int
+    memory_size: FpNum
+    state_write_counter: FpNum
 
     def __init__(
         self,

--- a/src/zkevm_specs/evm/step.py
+++ b/src/zkevm_specs/evm/step.py
@@ -1,6 +1,6 @@
 from typing import Any, Sequence
 from .execution_state import ExecutionState
-from ..util import FpNum, RLC
+from ..util import FQ, RLC
 
 
 class StepState:
@@ -14,8 +14,8 @@ class StepState:
     """
 
     execution_state: ExecutionState
-    rw_counter: FpNum
-    call_id: FpNum
+    rw_counter: FQ
+    call_id: FQ
 
     # The following 3 fields decide the opcode source. There are 2 possible
     # cases:
@@ -31,14 +31,14 @@ class StepState:
     code_source: RLC
 
     # The following fields change almost every step.
-    program_counter: FpNum
-    stack_pointer: FpNum
-    gas_left: FpNum
+    program_counter: FQ
+    stack_pointer: FQ
+    gas_left: FQ
 
     # The following fields could be further moved into rw_table if we find them
     # not often used.
-    memory_size: FpNum
-    state_write_counter: FpNum
+    memory_size: FQ
+    state_write_counter: FQ
 
     def __init__(
         self,
@@ -55,13 +55,13 @@ class StepState:
         state_write_counter: int = 0,
     ) -> None:
         self.execution_state = execution_state
-        self.rw_counter = FpNum(rw_counter)
-        self.call_id = FpNum(call_id)
+        self.rw_counter = FQ(rw_counter)
+        self.call_id = FQ(call_id)
         self.is_root = is_root
         self.is_create = is_create
         self.code_source = code_source
-        self.program_counter = FpNum(program_counter)
-        self.stack_pointer = FpNum(stack_pointer)
-        self.gas_left = FpNum(gas_left)
-        self.memory_size = FpNum(memory_size)
-        self.state_write_counter = FpNum(state_write_counter)
+        self.program_counter = FQ(program_counter)
+        self.stack_pointer = FQ(stack_pointer)
+        self.gas_left = FQ(gas_left)
+        self.memory_size = FQ(memory_size)
+        self.state_write_counter = FQ(state_write_counter)

--- a/src/zkevm_specs/evm/step.py
+++ b/src/zkevm_specs/evm/step.py
@@ -48,7 +48,7 @@ class StepState:
         is_root: bool = False,
         is_create: bool = False,
         code_source: int = 0,
-        program_counter: FpNum = FpNum(0),
+        program_counter: int = 0,
         stack_pointer: int = 1024,
         gas_left: int = 0,
         memory_size: int = 0,

--- a/src/zkevm_specs/evm/table.py
+++ b/src/zkevm_specs/evm/table.py
@@ -3,7 +3,7 @@ from typing import Sequence, Set, Tuple
 from enum import IntEnum, auto
 from itertools import chain, product
 
-from ..util import Array3, Array4, Array10
+from ..util import FpNum, Array3, Array4, Array10
 from .execution_state import ExecutionState
 from .opcode import (
     invalid_opcodes,
@@ -337,4 +337,4 @@ def _lookup(
     elif len(matched_rows) > 1:
         raise LookupAmbiguousFailure(table_name, inputs, matched_rows)
 
-    return matched_rows[0]
+    return [FpNum(v) if isinstance(v, int) else v for v in matched_rows[0]]

--- a/src/zkevm_specs/evm/table.py
+++ b/src/zkevm_specs/evm/table.py
@@ -3,7 +3,7 @@ from typing import Sequence, Set, Tuple
 from enum import IntEnum, auto
 from itertools import chain, product
 
-from ..util import FpNum, Array3, Array4, Array10
+from ..util import FQ, RLC, Array3, Array4, Array10
 from .execution_state import ExecutionState
 from .opcode import (
     invalid_opcodes,
@@ -337,4 +337,4 @@ def _lookup(
     elif len(matched_rows) > 1:
         raise LookupAmbiguousFailure(table_name, inputs, matched_rows)
 
-    return [FpNum(v) if isinstance(v, int) else v for v in matched_rows[0]]
+    return [v if isinstance(v, RLC) else FQ(v) for v in matched_rows[0]]

--- a/src/zkevm_specs/evm/typing.py
+++ b/src/zkevm_specs/evm/typing.py
@@ -103,7 +103,7 @@ class Transaction:
     def call_data_gas_cost(self) -> int:
         return reduce(
             lambda acc, byte: (
-                acc + (GAS_COST_TX_CALL_DATA_PER_ZERO_BYTE if byte is 0 else GAS_COST_TX_CALL_DATA_PER_NON_ZERO_BYTE)
+                acc + (GAS_COST_TX_CALL_DATA_PER_ZERO_BYTE if byte == 0 else GAS_COST_TX_CALL_DATA_PER_NON_ZERO_BYTE)
             ),
             self.call_data,
             0,

--- a/src/zkevm_specs/util/__init__.py
+++ b/src/zkevm_specs/util/__init__.py
@@ -13,7 +13,7 @@ def rand_range(stop: Union[int, float] = 2**256) -> int:
 
 
 def rand_fp() -> int:
-    return rand_range(FpNum.FP_MODULUS)
+    return rand_range(FQ.field_modulus)
 
 
 def rand_address() -> U160:

--- a/src/zkevm_specs/util/__init__.py
+++ b/src/zkevm_specs/util/__init__.py
@@ -13,7 +13,7 @@ def rand_range(stop: Union[int, float] = 2**256) -> int:
 
 
 def rand_fp() -> int:
-    return rand_range(FP_MODULUS)
+    return rand_range(FpNum.FP_MODULUS)
 
 
 def rand_address() -> U160:

--- a/src/zkevm_specs/util/arithmetic.py
+++ b/src/zkevm_specs/util/arithmetic.py
@@ -1,38 +1,80 @@
 from __future__ import annotations
 from typing import Sequence, Union
 
-# BN254 scalar field size
-FP_MODULUS = 21888242871839275222246405745257275088548364400416034343698204186575808495617
+
+class FpNum:
+    """FpNum represents the value in the BN254 scalar field."""
+
+    # BN254 scalar field size
+    FP_MODULUS = 21888242871839275222246405745257275088548364400416034343698204186575808495617
+
+    def __init__(self, value: Union[int, FpNum]):
+        if isinstance(value, int):
+            self.value = value % FpNum.FP_MODULUS
+        elif isinstance(value, FpNum):
+            self.value = value.value
+        else:
+            raise TypeError(f"Expect int or FpNum, but get type {type(value)}")
+
+    def __add__(self, other: Union[int, FpNum]) -> FpNum:
+        return FpNum(self.value + FpNum(other).value)
+
+    def __radd__(self, other: Union[int, FpNum]) -> FpNum:
+        return self + other
+
+    def __sub__(self, other: Union[int, FpNum]) -> FpNum:
+        return FpNum(self.value - FpNum(other).value)
+
+    def __rsub__(self, other: Union[int, FpNum]) -> FpNum:
+        return FpNum(other) - self
+
+    def __neg__(self) -> FpNum:
+        return FpNum(-self.value)
+
+    def __mul__(self, other: Union[int, FpNum]) -> FpNum:
+        return FpNum(self.value * FpNum(other).value)
+
+    def __eq__(self, other: Union[int, FpNum]) -> bool:
+        return self.value == FpNum(other).value
+
+    def __lt__(self, other: Union[int, FpNum]) -> bool:
+        return self.value < FpNum(other).value
+
+    def __gt__(self, other: Union[int, FpNum]) -> bool:
+        return self.value > FpNum(other).value
+
+    def __hash__(self) -> int:
+        return hash(self.value)
+
+    def __str__(self) -> str:
+        return f"Fp({self.value})"
+
+    __repr__ = __str__
+
+    def inv(self) -> FpNum:
+        return FpNum(pow(value, -1, FpNum.FP_MODULUS))
 
 
-def fp_add(a: int, b: int) -> int:
-    return (a + b) % FP_MODULUS
-
-
-def fp_mul(a: int, b: int) -> int:
-    return (a * b) % FP_MODULUS
-
-
-def fp_inv(value: int) -> int:
-    return pow(value, -1, FP_MODULUS)
-
-
-def fp_linear_combine(le_bytes: Union[bytes, Sequence[int]], factor: int) -> int:
-    com = 0
+def fp_linear_combine(le_bytes: Union[bytes, Sequence[int]], factor: int) -> FpNum:
+    ret = FpNum(0)
+    factor = FpNum(factor)
     for byte in reversed(le_bytes):
         assert 0 <= byte < 256, "Each byte in le_bytes for linear combination should fit in 8-bit"
-        com = fp_add(fp_mul(com, factor), byte)
-    return com
+        ret = ret * factor + byte
+    return ret
 
 
 class RLC:
     le_bytes: bytes
-    value: int
+    value: FpNum
 
     def __init__(self, int_or_bytes: Union[int, bytes], randomness: int, n_bytes: int = 32) -> None:
         if isinstance(int_or_bytes, int):
             assert 0 <= int_or_bytes < 256**n_bytes, f"Value {int_or_bytes} too large to fit {n_bytes} bytes"
             self.le_bytes = int_or_bytes.to_bytes(n_bytes, "little")
+        elif isinstance(int_or_bytes, FpNum):
+            assert int_or_bytes.value < 256 ** n_bytes, f"Value {int_or_bytes} too large to fit {n_bytes} bytes"
+            self.le_bytes = int_or_bytes.value.to_bytes(n_bytes, "little")
         elif isinstance(int_or_bytes, bytes):
             assert len(int_or_bytes) <= n_bytes, f"Expected bytes with length less or equal than {n_bytes}"
             self.le_bytes = int_or_bytes.ljust(n_bytes, b"\x00")
@@ -41,8 +83,8 @@ class RLC:
 
         self.value = fp_linear_combine(self.le_bytes, randomness)
 
-    def __eq__(self, rhs: Union[int, RLC]):
-        if isinstance(rhs, int):
+    def __eq__(self, rhs: Union[int, FpNum, RLC]):
+        if isinstance(rhs, (int, FpNum)):
             return self.value == rhs
         if isinstance(rhs, RLC):
             return self.value == rhs.value
@@ -50,10 +92,10 @@ class RLC:
             raise TypeError(f"Expected a RLC, but got object of type {type(rhs)}")
 
     def __hash__(self) -> int:
-        return self.value
+        return hash(self.value)
 
     def __repr__(self) -> str:
-        return int.from_bytes(self.le_bytes, "little").__repr__()
+        return "RLC(%s)" % int.from_bytes(self.le_bytes, "little")
 
     def be_bytes(self) -> bytes:
         return bytes(reversed(self.le_bytes))

--- a/src/zkevm_specs/util/arithmetic.py
+++ b/src/zkevm_specs/util/arithmetic.py
@@ -29,7 +29,7 @@ class RLC:
             assert 0 <= int_or_bytes < 256**n_bytes, f"Value {int_or_bytes} too large to fit {n_bytes} bytes"
             self.le_bytes = int_or_bytes.to_bytes(n_bytes, "little")
         elif isinstance(int_or_bytes, FQ):
-            assert int_or_bytes.n < 256 ** n_bytes, f"Value {int_or_bytes} too large to fit {n_bytes} bytes"
+            assert int_or_bytes.n < 256**n_bytes, f"Value {int_or_bytes} too large to fit {n_bytes} bytes"
             self.le_bytes = int_or_bytes.n.to_bytes(n_bytes, "little")
         elif isinstance(int_or_bytes, bytes):
             assert len(int_or_bytes) <= n_bytes, f"Expected bytes with length less or equal than {n_bytes}"

--- a/src/zkevm_specs/util/arithmetic.py
+++ b/src/zkevm_specs/util/arithmetic.py
@@ -1,63 +1,19 @@
 from __future__ import annotations
 from typing import Sequence, Union
+from py_ecc.fields import bn128_FQ as FQ
 
 
-class FpNum:
-    """FpNum represents the value in the BN254 scalar field."""
-
-    # BN254 scalar field size
-    FP_MODULUS = 21888242871839275222246405745257275088548364400416034343698204186575808495617
-
-    def __init__(self, value: Union[int, FpNum]):
-        if isinstance(value, int):
-            self.value = value % FpNum.FP_MODULUS
-        elif isinstance(value, FpNum):
-            self.value = value.value
-        else:
-            raise TypeError(f"Expect int or FpNum, but get type {type(value)}")
-
-    def __add__(self, other: Union[int, FpNum]) -> FpNum:
-        return FpNum(self.value + FpNum(other).value)
-
-    def __radd__(self, other: Union[int, FpNum]) -> FpNum:
-        return self + other
-
-    def __sub__(self, other: Union[int, FpNum]) -> FpNum:
-        return FpNum(self.value - FpNum(other).value)
-
-    def __rsub__(self, other: Union[int, FpNum]) -> FpNum:
-        return FpNum(other) - self
-
-    def __neg__(self) -> FpNum:
-        return FpNum(-self.value)
-
-    def __mul__(self, other: Union[int, FpNum]) -> FpNum:
-        return FpNum(self.value * FpNum(other).value)
-
-    def __eq__(self, other: Union[int, FpNum]) -> bool:
-        return self.value == FpNum(other).value
-
-    def __lt__(self, other: Union[int, FpNum]) -> bool:
-        return self.value < FpNum(other).value
-
-    def __gt__(self, other: Union[int, FpNum]) -> bool:
-        return self.value > FpNum(other).value
-
-    def __hash__(self) -> int:
-        return hash(self.value)
-
-    def __str__(self) -> str:
-        return f"Fp({self.value})"
-
-    __repr__ = __str__
-
-    def inv(self) -> FpNum:
-        return FpNum(pow(value, -1, FpNum.FP_MODULUS))
+def _hash_fq(v: FQ) -> int:
+    return hash(v.n)
 
 
-def fp_linear_combine(le_bytes: Union[bytes, Sequence[int]], factor: int) -> FpNum:
-    ret = FpNum(0)
-    factor = FpNum(factor)
+FQ.__hash__ = _hash_fq
+IntOrFQ = Union[int, FQ]
+
+
+def fp_linear_combine(le_bytes: Union[bytes, Sequence[int]], factor: int) -> FQ:
+    ret = FQ.zero()
+    factor = FQ(factor)
     for byte in reversed(le_bytes):
         assert 0 <= byte < 256, "Each byte in le_bytes for linear combination should fit in 8-bit"
         ret = ret * factor + byte
@@ -66,15 +22,15 @@ def fp_linear_combine(le_bytes: Union[bytes, Sequence[int]], factor: int) -> FpN
 
 class RLC:
     le_bytes: bytes
-    value: FpNum
+    value: FQ
 
-    def __init__(self, int_or_bytes: Union[int, bytes], randomness: int, n_bytes: int = 32) -> None:
+    def __init__(self, int_or_bytes: Union[IntOrFQ, bytes], randomness: int, n_bytes: int = 32) -> None:
         if isinstance(int_or_bytes, int):
             assert 0 <= int_or_bytes < 256**n_bytes, f"Value {int_or_bytes} too large to fit {n_bytes} bytes"
             self.le_bytes = int_or_bytes.to_bytes(n_bytes, "little")
-        elif isinstance(int_or_bytes, FpNum):
-            assert int_or_bytes.value < 256 ** n_bytes, f"Value {int_or_bytes} too large to fit {n_bytes} bytes"
-            self.le_bytes = int_or_bytes.value.to_bytes(n_bytes, "little")
+        elif isinstance(int_or_bytes, FQ):
+            assert int_or_bytes.n < 256 ** n_bytes, f"Value {int_or_bytes} too large to fit {n_bytes} bytes"
+            self.le_bytes = int_or_bytes.n.to_bytes(n_bytes, "little")
         elif isinstance(int_or_bytes, bytes):
             assert len(int_or_bytes) <= n_bytes, f"Expected bytes with length less or equal than {n_bytes}"
             self.le_bytes = int_or_bytes.ljust(n_bytes, b"\x00")
@@ -83,8 +39,8 @@ class RLC:
 
         self.value = fp_linear_combine(self.le_bytes, randomness)
 
-    def __eq__(self, rhs: Union[int, FpNum, RLC]):
-        if isinstance(rhs, (int, FpNum)):
+    def __eq__(self, rhs: Union[int, FQ, RLC]):
+        if isinstance(rhs, (int, FQ)):
             return self.value == rhs
         if isinstance(rhs, RLC):
             return self.value == rhs.value

--- a/tests/evm/test_add.py
+++ b/tests/evm/test_add.py
@@ -75,3 +75,6 @@ def test_add(opcode: Opcode, a: int, b: int, c: Optional[int]):
             ),
         ],
     )
+
+
+test_add(*TESTING_DATA[0])

--- a/tests/evm/test_add.py
+++ b/tests/evm/test_add.py
@@ -75,6 +75,3 @@ def test_add(opcode: Opcode, a: int, b: int, c: Optional[int]):
             ),
         ],
     )
-
-
-test_add(*TESTING_DATA[0])

--- a/tests/test_bytecode_circuit.py
+++ b/tests/test_bytecode_circuit.py
@@ -120,8 +120,9 @@ def test_bytecode_invalid_index():
 
     # Don't increment an index once
     invalid = deepcopy(unrolled)
-    row = unrolled.rows[-1]
-    invalid.rows[-1] = (row[0].value - 1, row[1], row[2], row[3])
+    invalid_cell = invalid.rows[-1][0]
+    invalid_cell.value -= 1
+    invalid.rows[-1] = (invalid_cell, row[1], row[2], row[3])
     verify(k, [invalid], randomness, False)
 
 


### PR DESCRIPTION
Currently values in the Fp field all use int type in Python. There two drawbacks about this:
- There is potential overflow problem with int value
- Writing expression on these values requires to use `fp_add`, `fp_mul`, etc. It is quite annoying and makes the expression hard to understand.

Therefore, this PR replaces the values in the Fp field by `bn128_FQ` in the py-ecc package.