### PR TITLE
upgrade and pin dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ where = src
 
 [options.extras_require]
 test =
-    pytest
+    pytest >= 7.0.0
 lint =
-    black
-    mdformat
+    black >= 22.1.0
+    mdformat >= 0.7.13


### PR DESCRIPTION
### Problem

The package black has a new update released, causing some confusion. The CI checks the formatting with the new version but the developers' local old versions disagree with the formatting.

### Solution

We need to pin the versions of the packages to prevent CI from using a new version that we haven't explicitly upgraded.

Note: Run `make install` after this PR is merged.