### PR TITLE
Redo spec of state circuit

### DIFF
--- a/specs/state-proof.md
+++ b/specs/state-proof.md
@@ -1,376 +1,47 @@
 # State Proof
 
-The state proof helps EVM proof to check all the random read-write access records are valid, through grouping them by their unique index first, and then sorting them by order of access. We call the order of access `GlobalCounter`, which counts the number of access records and also serves as an unique identifier for a record. When state proof is generated, the `BusMapping` is also produced and will be shared to EVM proof as a lookup table.
+The state proof helps EVM proof to check all the random read-write access records are valid, through grouping them by their unique index first, and then sorting them by order of access. We call the order of access `ReadWriteCounter`, which counts the number of access records and also serves as an unique identifier for a record. When state proof is generated, the `BusMapping` is also produced and will be shared to EVM proof as a lookup table.
 
 ## Random Read-Write Data
 
-State proof maintains the read-write part of [random accessible data](./evm-proof.md#Random-Accessible-Data) of EVM proof:
+State proof maintains the read-write part of [random accessible data](./evm-proof.md#Random-Accessible-Data) of EVM proof.
 
-| Target                                | Index             | Description                              |
-| ------------------------------------- | ----------------- | ---------------------------------------- |
-| [`AccountNonce`](#AccountNonce)       | `{address}`       | Account's nonce                          |
-| [`AccountBalance`](#AccountBalance)   | `{address}`       | Account's balance                        |
-| [`AccountCodeHash`](#AccountCodeHash) | `{address}`       | Account's code hash                      |
-| [`AccountStorage`](#AccountStorage)   | `{address}.{key}` | Account's storage as a key-value mapping |
-| [`CallState`](#CallState)             | `{id}.{enum}`     | Call's internal state                    |
-| [`CallStateStack`](#CallStateStack)   | `{id}.{index}`    | Call's stack as a encoded word array     |
-| [`CallStateMemory`](#CallStateMemory) | `{id}.{index}`    | Call's memory as a byte array            |
+The operations recorded in the state proof are:
 
-The concatenation of **Target** and **Index** becomes the unique index for data. Each record will be attached with a `GlobalCounter`, and the records are constraint to be in group by their unique index first and to be sorted by their `GlobalCounter` increasingly. Given the access to previous record, each target has their own format and rules to update, for example, `AccountNonce` always increase by 1, and values in `CallStateMemory` should fit in 8-bit.
+- `Memory`: Call's memory as a byte array
+- `Stack`: Call's stack as RLC-encoded word array
+- `Storage`: Account's storage as key-value mapping
+- `CallContext`: Context of a Call
+- `Account`: Account's state (nonce, balance, code hash)
+- `TxRefund`: Value to refund to the tx sender
+- `TxAccessListAccount`: State of the account access list
+- `TxAccessListAccountStorage`: State of the account storage access list
+- `AccountDestructed`: State of destruction of an account
 
-## Constants
+Each operation uses diferent parameters for indexing.  See [RW Table](./tables.md#rw_table) for the complete details.
 
-| Name                 | Value              | Description                                                                               |
-| -------------------- | ------------------ | ----------------------------------------------------------------------------------------- |
-| `MAX_U8`             | `2**8 - 1 (255)`   | Maximum value of u8 (byte)                                                                |
-| `MAX_STACK_INDEX`    | `2**10 - 1 (1023)` | Maximum index of stack (EVM has maximum stack size 1024)                                  |
-| `MAX_GLOBAL_COUNTER` | `2**25 - 1`        | Maximum number of `GlobalCounter`, which is also the maximum degree of polynomial allowed |
+The concatenation of all table keys becomes the unique index for data. Each record will be attached with a `ReadWriteCounter`, and the records are constraint to be in group by their unique index first and to be sorted by their `ReadWriteCounter` increasingly. Given the access to previous record, each target has their own format and rules to update, for example, values in `Memory` should fit in 8-bit.
 
 ## Circuit Constraints
 
-The following part describes the custom constraints for each target by a python script. There are some common helper class and function:
-
-```python
-class RW(Enum):
-    Read: int = 0
-    Write: int = 1
-
-    def __sub__(self, _):
-        return None
-
-
-class Record:
-    fields: Tuple[str]
-    values: object
-
-    def __init__(self, **kwargs) -> None:
-        self.values = {}
-        self.fields = tuple(["global_counter", "rw"] + self.fields)
-        for field in self.fields:
-            self.values[field] = kwargs[field]
-            setattr(self, field, self.values[field])
-
-    def __sub__(self, rhs):
-        if rhs is None:
-            return self
-        return type(self)(
-            **{field: self.values[field] - rhs.values[field] for field in self.fields}
-        )
-
-
-class ReadWriteGate:
-    group_fields: Tuple[(str, Callable)]
-
-    def constraint(self, prev, cur):
-        diff = cur - prev
-
-        is_first_row = prev is None
-        is_first_row_in_group = is_first_row or any(
-            [getattr(diff, field) != 0 for field, _ in self.group_fields]
-        )
-
-        # grouping
-        if not is_first_row:
-            for field, group_fn in self.group_fields:
-                assert group_fn(cur, prev, diff)
-                if getattr(diff, field) != 0:
-                    break
-
-        # rw should be valid
-        assert cur.rw in (RW.Read, RW.Write)
-
-        # global counter should increase in group
-        if not is_first_row_in_group:
-            assert 0 < diff.global_counter <= MAX_GLOBAL_COUNTER
-
-        type(self).constraint_every_row(cur)
-        type(self).constraint_in_group(prev, cur, diff, is_first_row_in_group)
-
-    @abstractclassmethod
-    def constraint_every_row(cur):
-        raise NotImplemented
-
-    @abstractclassmethod
-    def constraint_in_group(prev, cur, diff, is_first_row_in_group):
-        raise NotImplemented
-```
-
-### `AccountNonce`
-
-| Field     | Description     |
-| --------- | --------------- |
-| `address` | Account address |
-| `nonce`   | Account nonce   |
-
-```python
-class AccountNonce(Record):
-    fields = ["address", "nonce"]
-
-
-class AccountNonceGate(ReadWriteGate):
-    group_fields = [
-        # TODO: check address by 160-bit range lookup or other more efficient method
-        ("address", lambda cur, prev, diff: diff.address >= 0)
-    ]
-
-    def constraint_every_row(cur: AccountNonce):
-        # rw should be a Write (currently evm doesn't support read nonce)
-        assert cur.rw == RW.Write
-
-        # NOTE: we don't need to check each address is in [0, 2**160) becasue in
-        #       evm circuit it always decompress the address into bytes, which might
-        #       come from stack or tx. In both case, evm takes masked value, so evm
-        #       circuit only cares first 20 bytes, which will always be in range.
-
-    def constraint_in_group(
-        prev: AccountNonce,
-        cur: AccountNonce,
-        diff: AccountNonce,
-        is_first_row_in_group: bool,
-    ):
-        if is_first_row_in_group:
-            # TODO: verify the nonce exist in previous state trie root or initialized to 0
-            pass
-        else:
-            # nonce can only increase by 1
-            assert diff.nonce == 1
-```
-
-### `AccountBalance`
-
-| Field     | Description                    |
-| --------- | ------------------------------ |
-| `address` | Account address                |
-| `balance` | Account balance (encoded word) |
-
-```python
-class AccountBalance(Record):
-    fields = ["address", "balance"]
-
-
-class AccountBalanceGate(ReadWriteGate):
-    group_fields = [
-        # TODO: check address by 160-bit range lookup or other more efficient method
-        ("address", lambda cur, prev, diff: diff.address >= 0)
-    ]
-
-    def constraint_every_row(cur: AccountBalance):
-        # NOTE: we don't need to check each address (same reason of AccountNonce)
-        pass
-
-    def constraint_in_group(
-        prev: AccountBalance,
-        cur: AccountBalance,
-        diff: AccountBalance,
-        is_first_row_in_group: bool,
-    ):
-        if is_first_row_in_group:
-            # rw should be a Write for the first row in group
-            assert cur.rw == RW.Write
-
-            # TODO: verify the balance exist in previous state trie root or initialized to 0
-        else:
-            if cur.rw == RW.Read:
-                # balance should be consistent to previous one
-                assert diff.balance == 0
-```
-
-### `AccountCodeHash`
-
-**TODO**
-
-### `AccountStorage`
-
-**TODO** - add field `is_cold_load` for [`EIP2929`](https://eips.ethereum.org/EIPS/eip-2929) and [`EIP2930`](https://eips.ethereum.org/EIPS/eip-2930).
-
-| Field        | Description                                                         |
-| ------------ | ------------------------------------------------------------------- |
-| `address`    | Account address                                                     |
-| `key`        | Storage key (encoded word)                                          |
-| `value`      | Storage value (encoded word)                                        |
-| `value_prev` | Storage value in previous record, used for reverting (encoded word) |
-
-```python
-class AccountStorage(Record):
-    fields = ["address", "key", "value", "value_prev"]
-
-
-class AccountStorageGate(ReadWriteGate):
-    group_fields = [
-        # TODO: check address by 160-bit range lookup or other more efficient method
-        ("address", lambda cur, prev, diff: diff.address >= 0),
-        # TODO: check key by bytes comparator in case overflow
-        ("key", lambda cur, prev, diff: cur.key >= prev.key),
-    ]
-
-    def constraint_every_row(cur: AccountStorage):
-        # NOTE: we don't need to check each address (same reason of AccountNonce)
-        pass
-
-    def constraint_in_group(
-        prev: AccountStorage,
-        cur: AccountStorage,
-        diff: AccountStorage,
-        is_first_row_in_group: bool,
-    ):
-        if is_first_row_in_group:
-            # rw should be a Write for the first row in group
-            assert cur.rw == RW.Write
-
-            # TODO: verify the storage exist in previous state trie root or initialized to 0
-        else:
-            if cur.rw == RW.Read:
-                # value and value_prev should be consistent to previous one
-                assert diff.value == 0 and diff.value_prev == 0
-            elif cur.rw == RW.Write:
-                # value_prev should be previous one
-                assert cur.value_prev == prev.value
-```
-
-### `CallState`
-
-| Field   | Description                             |
-| ------- | --------------------------------------- |
-| `id`    | Call id                                 |
-| `enum`  | State field as a enum (`CallStateEnum`) |
-| `value` | State value (encoded word)              |
-
-```python
-class CallStateEnum(Enum):
-    ProgramCounter = 1
-    StackPointer = 2
-    MemeorySize = 3
-    GasCounter = 4
-    StateWriteCounter = 5
-    CalleeId = 6
-    ReturndataOffset = 7
-    ReturndataSize = 8
-
-    def __sub__(self, rhs):
-        return self.value - rhs.value
-
-
-class CallState(Record):
-    fields = ["id", "enum", "value"]
-
-
-class CallStateGate(ReadWriteGate):
-    group_fields = [
-        # TODO: decide a reasonable call id range circuit should support
-        ("id", lambda cur, prev, diff: diff.id >= 0),
-        # enum should increase by 1 or remain
-        ("enum", lambda cur, prev, diff: diff.enum in (0, 1)),
-    ]
-
-    def constraint_every_row(cur: CallState):
-        # enum should be valid
-        assert 0 < cur.enum.value <= len(CallStateEnum)
-
-    def constraint_in_group(
-        prev: CallState, cur: CallState, diff: CallState, is_first_row_in_group: bool
-    ):
-        if is_first_row_in_group:
-            # rw should be a Write for the first row in group
-            assert cur.rw == RW.Write
-        else:
-            if cur.rw == RW.Read:
-                # value should be consistent to previous one
-                assert diff.value == 0
-```
-
-### `CallStateStack`
-
-| Field   | Description                |
-| ------- | -------------------------- |
-| `id`    | Call id                    |
-| `index` | Stack index                |
-| `value` | Stack value (encoded word) |
-
-```python
-class CallStateStack(Record):
-    fields = ["id", "index", "value"]
-
-
-class CallStateStackGate(ReadWriteGate):
-    group_fields = [
-        # TODO: decide a reasonable call id range circuit should support
-        ("id", lambda cur, prev, diff: diff.id >= 0),
-        # index should increase by 1 or remain
-        ("index", lambda cur, prev, diff: diff.index in (0, 1)),
-    ]
-
-    def constraint_every_row(cur: CallStateStack):
-        # index should be valid (avoid malicious prover to conceal stack overflow / underflow error)
-        assert 0 <= cur.index <= MAX_STACK_INDEX
-
-    def constraint_in_group(
-        prev: CallStateStack,
-        cur: CallStateStack,
-        diff: CallStateStack,
-        is_first_row_in_group: bool,
-    ):
-        if is_first_row_in_group:
-            # rw should be a Write for the first row in group
-            assert cur.rw == RW.Write
-        else:
-            if cur.rw == RW.Read:
-                # value should be consistent to previous one
-                assert diff.value == 0
-```
-
-### `CallStateMemory`
-
-| Field   | Description         |
-| ------- | ------------------- |
-| `id`    | Call id             |
-| `index` | Memory index        |
-| `value` | Memory value (byte) |
-
-```python
-class CallStateMemory(Record):
-    fields = ["id", "index", "value"]
-
-
-class CallStateMemoryGate(ReadWriteGate):
-    group_fields = [
-        # TODO: decide a reasonable call id range circuit should support
-        ("id", lambda cur, prev, diff: diff.id >= 0),
-        # TODO: decide a reasonable memory index range circuit should support
-        ("index", lambda cur, prev, diff: diff.index >= 0),
-    ]
-
-    def constraint_every_row(cur: CallStateMemory):
-        # TODO: decide where to check memory index range, we have 2 choices:
-        #       1. check in state circuit: we decide a reasonable hard bound and do
-        #          range lookup check
-        #       2. check in evm circuit: memory index always comes from stack, so it
-        #          will be decompress into bytes in evm circuit, we can just pick the
-        #          first n bytes (say 3 bytes) to recompose the memory index and
-        #          lookup bus mapping. When the left 32-n bytes are non-zero, it
-        #          should always cause an out-of-gas error (expansion of memory size
-        #          to 2**24 leads to gas cost 538,443,776).
-
-        # value should be a byte
-        assert 0 <= cur.value <= MAX_U8
-
-    def constraint_in_group(
-        prev: CallStateMemory,
-        cur: CallStateMemory,
-        diff: CallStateMemory,
-        is_first_row_in_group: bool,
-    ):
-        if is_first_row_in_group:
-            # rw should be a Write for the first row in group
-            assert cur.rw == RW.Write
-
-            # value should be 0 for the first row in group
-            assert cur.value == 0
-        else:
-            if cur.rw == RW.Read:
-                # value should be consistent to previous one
-                assert diff.value == 0
-```
-
-## Circuit Layout
-
-**TODO**
+The constraints are divided into two groups:
+
+- Global constraints that affect all operations, like the lexicographic order of keys.
+- Particular constraints to each operation.  A selector-like expression is used for every operation type to enable extra constraints that only apply to that operation.
+
+For all the constraints that must guarantee proper ordering/transition of
+values we use range checks of the difference between the consecutive cells,
+with the help of fixed lookup tables.  Since we use lookup tables to prove
+correct ordering, for every column that must be sorted we need to define the
+maximum value it can contain (which will correspond to the fixed lookup table
+size); this way, two consecutive cells in order will have a difference that is
+found in the table, and a reverse ordering will make the difference to wrap
+around to a very high value (due to the field arithmetic), causing the result
+to not be in the table.
+
+The exact list of constraints is documented in detail as comments in the python
+code implementation.
+
+## Code
+
+Please refer to `src/zkevm-specs/state.py`

--- a/specs/tables.md
+++ b/specs/tables.md
@@ -45,56 +45,57 @@ Type sizes:
 > - **memoryAddress**: 40 bytes
 > - **Memory -> value, valuePrev**: 1 byte
 > - **storageKey**: field size, RLC encoded (Random Linear Combination)
-> - **value, valuePrev**: variable size, depending on *Key 1 (Tag)* and *Key 3*
->   where appropiate.
+> - **value, valuePrev**: variable size, depending on Key 0 (Tag) and Key 3 where appropiate.
+> - **Key2** is reserved for Ethereum Address key type
+> - **Key4** is reserved for RLC encoded key type
 
-| 0 *rwc*  | 1 *isWrite* | 2 *Key 1 (Tag)*            | 3 *Key 2* | 4 *Key 3*                  | 5 *Key 4*   | 6 *Value 1* | 7 *Value 2* | 8 *Aux 1* | 9 *Aux 2*       |
-| ---      | ---         | ---                        | ---       | ---                        | ---         | ---         | ---         | ---       | ---             |
-|          |             | *RwTableTag*               |           |                            |             |             |             |           |                 |
-| $counter | true        | TxAccessListAccount        | $txID     | $address                   | 0           | $value      | $valuePrev  | 0         | 0               |
-| $counter | true        | TxAccessListAccountStorage | $txID     | $address                   | $storageKey | $value      | $valuePrev  | 0         | 0               |
-| $counter | $isWrite    | TxRefund                   | $txID     | 0                          | 0           | $value      | $valuePrev  | 0         | 0               |
-|          |             |                            |           |                            |             |             |             |           |                 |
-|          |             |                            |           | *AccountFieldTag*          |             |             |             |           |                 |
-| $counter | $isWrite    | Account                    | $address  | Nonce                      | 0           | $value      | $valuePrev  | 0         | 0               |
-| $counter | $isWrite    | Account                    | $address  | Balance                    | 0           | $value      | $valuePrev  | 0         | 0               |
-| $counter | $isWrite    | Account                    | $address  | CodeHash                   | 0           | $value      | $valuePrev  | 0         | 0               |
-| $counter | true        | AccountDestructed          | $address  | 0                          | 0           | $value      | $valuePrev  | 0         | 0               |
-|          |             |                            |           |                            |             |             |             |           |                 |
-|          |             | *CallContext constant*     |           | *CallContextFieldTag* (ro) |             |             |             |           |                 |
-| $counter | false       | CallContext                | $callID   | RwCounterEndOfReversion    | 0           | $value      | 0           | 0         | 0               |
-| $counter | false       | CallContext                | $callID   | CallerId                   | 0           | $value      | 0           | 0         | 0               |
-| $counter | false       | CallContext                | $callID   | TxId                       | 0           | $value      | 0           | 0         | 0               |
-| $counter | false       | CallContext                | $callID   | Depth                      | 0           | $value      | 0           | 0         | 0               |
-| $counter | false       | CallContext                | $callID   | CallerAddress              | 0           | $value      | 0           | 0         | 0               |
-| $counter | false       | CallContext                | $callID   | CalleeAddress              | 0           | $value      | 0           | 0         | 0               |
-| $counter | false       | CallContext                | $callID   | CallDataOffset             | 0           | $value      | 0           | 0         | 0               |
-| $counter | false       | CallContext                | $callID   | CallDataLength             | 0           | $value      | 0           | 0         | 0               |
-| $counter | false       | CallContext                | $callID   | ReturnDataOffset           | 0           | $value      | 0           | 0         | 0               |
-| $counter | false       | CallContext                | $callID   | ReturnDataLength           | 0           | $value      | 0           | 0         | 0               |
-| $counter | false       | CallContext                | $callID   | Value                      | 0           | $value      | 0           | 0         | 0               |
-| $counter | false       | CallContext                | $callID   | Result                     | 0           | $value      | 0           | 0         | 0               |
-| $counter | false       | CallContext                | $callID   | IsPersistent               | 0           | $value      | 0           | 0         | 0               |
-| $counter | false       | CallContext                | $callID   | IsStatic                   | 0           | $value      | 0           | 0         | 0               |
-|          |             |                            |           |                            |             |             |             |           |                 |
-|          |             | *CallContext last callee*  |           | *CallContextFieldTag* (rw) |             |             |             |           |                 |
-| $counter | false       | CallContext                | $callID   | LastCalleeId               | 0           | $value      | 0           | 0         | 0               |
-| $counter | false       | CallContext                | $callID   | LastCalleeReturnDataOffset | 0           | $value      | 0           | 0         | 0               |
-| $counter | false       | CallContext                | $callID   | LastCalleeReturnDataLength | 0           | $value      | 0           | 0         | 0               |
-|          |             |                            |           |                            |             |             |             |           |                 |
-|          |             | *CallContext state*        |           | *CallContextFieldTag* (rw) |             |             |             |           |                 |
-| $counter | $isWrite    | CallContext                | $callID   | IsRoot                     | 0           | $value      | 0           | 0         | 0               |
-| $counter | $isWrite    | CallContext                | $callID   | IsCreate                   | 0           | $value      | 0           | 0         | 0               |
-| $counter | $isWrite    | CallContext                | $callID   | CodeSource                 | 0           | $value      | 0           | 0         | 0               |
-| $counter | $isWrite    | CallContext                | $callID   | ProgramCounter             | 0           | $value      | 0           | 0         | 0               |
-| $counter | $isWrite    | CallContext                | $callID   | StackPointer               | 0           | $value      | 0           | 0         | 0               |
-| $counter | $isWrite    | CallContext                | $callID   | GasLeft                    | 0           | $value      | 0           | 0         | 0               |
-| $counter | $isWrite    | CallContext                | $callID   | MemorySize                 | 0           | $value      | 0           | 0         | 0               |
-| $counter | $isWrite    | CallContext                | $callID   | StateWriteCounter          | 0           | $value      | 0           | 0         | 0               |
-|          |             |                            |           |                            |             |             |             |           |                 |
-| $counter | $isWrite    | Stack                      | $callID   | $stackPointer              | 0           | $value      | 0           | 0         | 0               |
-| $counter | $isWrite    | Memory                     | $callID   | $memoryAddress             | 0           | $value      | 0           | 0         | 0               |
-| $counter | $isWrite    | AccountStorage             | $address  | 0                          | $storageKey | $value      | $valuePrev  | $txID     | $CommittedValue |
+| 0 *rwc*  | 1 *isWrite* | 2 *Key0 (Tag)*             | 3 *Key1* | 4 *Key2* | 5 *Key3*                   | 6 *Key4*    | 7 *Value0* | 8 *Value1* | 9 *Aux0* | 10 *Aux1*       |
+| -------- | ----------- | -------------------------- | -------- | -------- | -------------------------- | ----------- | ---------  | ---------- | -------- | --------------- |
+|          |             | *RwTableTag*               |          |          |                            |             |            |            |          |                 |
+| $counter | true        | TxAccessListAccount        | $txID    | $address |                            |             | $value     | $valuePrev | 0        | 0               |
+| $counter | true        | TxAccessListAccountStorage | $txID    | $address |                            | $storageKey | $value     | $valuePrev |          | 0               |
+| $counter | $isWrite    | TxRefund                   | $txID    |          |                            |             | $value     | $valuePrev | 0        | 0               |
+|          |             |                            |          |          |                            |             |            |            |          |                 |
+|          |             |                            |          |          | *AccountFieldTag*          |             |            |            |          |                 |
+| $counter | $isWrite    | Account                    |          | $address | Nonce                      |             | $value     | $valuePrev | 0        | 0               |
+| $counter | $isWrite    | Account                    |          | $address | Balance                    |             | $value     | $valuePrev | 0        | 0               |
+| $counter | $isWrite    | Account                    |          | $address | CodeHash                   |             | $value     | $valuePrev | 0        | 0               |
+| $counter | true        | AccountDestructed          |          | $address |                            |             | $value     | $valuePrev | 0        | 0               |
+|          |             |                            |          |          |                            |             |            |            |          |                 |
+|          |             | *CallContext constant*     |          |          | *CallContextFieldTag* (ro) |             |            |            |          |                 |
+| $counter | false       | CallContext                | $callID  |          | RwCounterEndOfReversion    |             | $value     | 0          | 0        | 0               |
+| $counter | false       | CallContext                | $callID  |          | CallerId                   |             | $value     | 0          | 0        | 0               |
+| $counter | false       | CallContext                | $callID  |          | TxId                       |             | $value     | 0          | 0        | 0               |
+| $counter | false       | CallContext                | $callID  |          | Depth                      |             | $value     | 0          | 0        | 0               |
+| $counter | false       | CallContext                | $callID  |          | CallerAddress              |             | $value     | 0          | 0        | 0               |
+| $counter | false       | CallContext                | $callID  |          | CalleeAddress              |             | $value     | 0          | 0        | 0               |
+| $counter | false       | CallContext                | $callID  |          | CallDataOffset             |             | $value     | 0          | 0        | 0               |
+| $counter | false       | CallContext                | $callID  |          | CallDataLength             |             | $value     | 0          | 0        | 0               |
+| $counter | false       | CallContext                | $callID  |          | ReturnDataOffset           |             | $value     | 0          | 0        | 0               |
+| $counter | false       | CallContext                | $callID  |          | ReturnDataLength           |             | $value     | 0          | 0        | 0               |
+| $counter | false       | CallContext                | $callID  |          | Value                      |             | $value     | 0          | 0        | 0               |
+| $counter | false       | CallContext                | $callID  |          | IsSuccess                  |             | $value     | 0          | 0        | 0               |
+| $counter | false       | CallContext                | $callID  |          | IsPersistent               |             | $value     | 0          | 0        | 0               |
+| $counter | false       | CallContext                | $callID  |          | IsStatic                   |             | $value     | 0          | 0        | 0               |
+|          |             |                            |          |          |                            |             |            |            |          |                 |
+|          |             | *CallContext last callee*  |          |          | *CallContextFieldTag* (rw) |             |            |            |          |                 |
+| $counter | $isWrite    | CallContext                | $callID  |          | LastCalleeId               |             | $value     | 0          | 0        | 0               |
+| $counter | $isWrite    | CallContext                | $callID  |          | LastCalleeReturnDataOffset |             | $value     | 0          | 0        | 0               |
+| $counter | $isWrite    | CallContext                | $callID  |          | LastCalleeReturnDataLength |             | $value     | 0          | 0        | 0               |
+|          |             |                            |          |          |                            |             |            |            |          |                 |
+|          |             | *CallContext state*        |          |          | *CallContextFieldTag* (rw) |             |            |            |          |                 |
+| $counter | $isWrite    | CallContext                | $callID  |          | IsRoot                     |             | $value     | 0          | 0        | 0               |
+| $counter | $isWrite    | CallContext                | $callID  |          | IsCreate                   |             | $value     | 0          | 0        | 0               |
+| $counter | $isWrite    | CallContext                | $callID  |          | CodeSource                 |             | $value     | 0          | 0        | 0               |
+| $counter | $isWrite    | CallContext                | $callID  |          | ProgramCounter             |             | $value     | 0          | 0        | 0               |
+| $counter | $isWrite    | CallContext                | $callID  |          | StackPointer               |             | $value     | 0          | 0        | 0               |
+| $counter | $isWrite    | CallContext                | $callID  |          | GasLeft                    |             | $value     | 0          | 0        | 0               |
+| $counter | $isWrite    | CallContext                | $callID  |          | MemorySize                 |             | $value     | 0          | 0        | 0               |
+| $counter | $isWrite    | CallContext                | $callID  |          | StateWriteCounter          |             | $value     | 0          | 0        | 0               |
+|          |             |                            |          |          |                            |             |            |            |          |                 |
+| $counter | $isWrite    | Stack                      | $callID  |          | $stackPointer              |             | $value     | 0          | 0        | 0               |
+| $counter | $isWrite    | Memory                     | $callID  |          | $memoryAddress             |             | $value     | 0          | 0        | 0               |
+| $counter | $isWrite    | AccountStorage             |          | $address |                            | $storageKey | $value     | $valuePrev | $txID    | $CommittedValue |
 
 ## `bytecode_table`
 

--- a/src/zkevm_specs/evm/table.py
+++ b/src/zkevm_specs/evm/table.py
@@ -283,14 +283,14 @@ class Tables:
     # Each row in RWTable contains:
     # - rw_counter
     # - is_write
-    # - key1 (tag)
+    # - key0 (tag)
+    # - key1
     # - key2
     # - key3
-    # - key4
     # - value
     # - value_prev
+    # - aux0
     # - aux1
-    # - aux2
     rw_table: Set[Array10]
 
     def __init__(

--- a/src/zkevm_specs/state.py
+++ b/src/zkevm_specs/state.py
@@ -1,0 +1,568 @@
+from typing import NamedTuple, Tuple, List, Sequence
+from enum import IntEnum, auto
+from math import log, ceil
+from .util import FQ, RLC, U160, U256
+from .encoding import U8, is_circuit_code
+from .evm import RW, RWTableTag
+from .evm import AccountFieldTag, CallContextFieldTag
+
+MAX_KEY_DIFF = 2**32 - 1
+MAX_MEMORY_ADDRESS = 2**32 - 1
+MAX_STACK_PTR = 1023
+MAX_KEY0 = 10  # Number of Tag variants
+MAX_KEY1 = 2**16 - 1  # Maximum number of calls in a block
+MAX_KEY2 = 2**160 - 1  # Ethereum Address size
+MAX_KEY3 = 2**40 - 1  # Maximum value for Memory Address
+KEY0_BITS = ceil(log(MAX_KEY0 + 1, 2))  # 4
+KEY1_BITS = ceil(log(MAX_KEY1 + 1, 2))  # 16
+KEY2_BITS = ceil(log(MAX_KEY2 + 1, 2))  # 160
+KEY3_BITS = ceil(log(MAX_KEY3 + 1, 2))  # 40
+
+
+class Tag(IntEnum):
+    """
+    Tag used as first key in the State Circuit Rows to "select" the operation target.
+    """
+
+    # Start Tag is used both as padding before the rest of the operations and
+    # also to discard constraints with the previous row that would fail due to
+    # wrapping around with the end of the table.
+    Start = 1
+    Memory = 2
+    Stack = 3
+    Storage = 4
+    CallContext = 5
+    Account = 6
+    TxRefund = 7
+    TxAccessListAccount = 8
+    TxAccessListAccountStorage = 9
+    AccountDestructed = 10
+
+
+class Row(NamedTuple):
+    """
+    State circuit row
+    """
+
+    # fmt: off
+    rw_counter: FQ
+    is_write: FQ # boolean
+    # key0 takes the Tag value used to select the constraints of a particular
+    # operation; the rest of they keys are used differently for each operation.
+    # See the meaning of each key for each operation in ../../specs/tables.md
+    # key2 is 160bit Address.  key4 is RLC encoded
+    keys: Tuple[FQ, FQ, FQ, FQ, FQ]
+    key2_limbs: Tuple[FQ, FQ, FQ, FQ, FQ, # key2 in Little-Endian (limbs in base 2**16)
+                      FQ, FQ, FQ, FQ, FQ]
+    key4_bytes: Tuple[FQ,FQ,FQ,FQ,FQ,FQ,FQ,FQ, # key4 in Little-Endian (limbs in base 2**8)
+                      FQ,FQ,FQ,FQ,FQ,FQ,FQ,FQ,
+                      FQ,FQ,FQ,FQ,FQ,FQ,FQ,FQ,
+                      FQ,FQ,FQ,FQ,FQ,FQ,FQ,FQ]
+    value: FQ
+    auxs: Tuple[FQ, FQ]
+    # fmt: on
+
+    def tag(self):
+        return self.keys[0]
+
+
+def linear_combine(limbs: Sequence[FQ], base: FQ) -> FQ:
+    ret = FQ.zero()
+    for limb in reversed(limbs):
+        ret = ret * base + limb
+    return ret
+
+
+# Boolean Expression builder
+def all_keys_eq(row: Row, row_prev: Row) -> bool:
+    eq = True
+    for i in range(len(row.keys)):
+        eq = eq and (row.keys[i] == row_prev.keys[i])
+    return eq
+
+
+# Comparison gadget.  Returns:
+# - eq = (lhs == rhs)
+# - lt = (lhs < rhs)
+class ComparisonGadget:
+    eq: bool
+    lt: bool
+
+    def __init__(self, lhs: FQ, rhs: FQ):
+        self.eq = lhs.n == rhs.n
+        self.lt = lhs.n < rhs.n
+
+    def __repr__(self):
+        return f"ComparisonGadget(eq: {self.eq}, lt: {self.lt})"
+
+
+@is_circuit_code
+def assert_in_range(x: FQ, min_val: int, max_val: int) -> None:
+    assert min_val <= x.n and x.n <= max_val
+
+
+@is_circuit_code
+def check_start(row: Row, row_prev: Row):
+    # 0. rw_counter is 0
+    assert row.rw_counter == 0
+
+
+@is_circuit_code
+def check_memory(row: Row, row_prev: Row):
+    get_call_id = lambda row: row.keys[1]
+    get_mem_addr = lambda row: row.keys[3]
+
+    # 0. Unused keys are 0
+    assert row.keys[2] == 0
+    assert row.keys[4] == 0
+
+    # 1. First access for a set of all keys
+    #
+    # When the set of all keys changes (first access of an address in a call)
+    # - If READ, value must be 0
+    if not all_keys_eq(row, row_prev) and row.is_write == 0:
+        assert row.value == 0
+
+    # 2. mem_addr in range
+    mem_addr = get_mem_addr(row)
+    assert_in_range(mem_addr, 0, MAX_MEMORY_ADDRESS)
+
+    # 3. value is a byte
+    assert_in_range(row.value, 0, 2**8 - 1)
+
+
+@is_circuit_code
+def check_stack(row: Row, row_prev: Row):
+    get_call_id = lambda row: row.keys[1]
+    get_stack_ptr = lambda row: row.keys[3]
+
+    # 0. Unused keys are 0
+    assert row.keys[2] == 0
+    assert row.keys[4] == 0
+
+    # 1. First access for a set of all keys
+    #
+    # The first stack operation in a stack position is always a write (can't
+    # read if it isn't written before)
+    #
+    # When the set of all keys changes (first access of a stack position in a call)
+    # - It must be a WRITE
+    if not all_keys_eq(row, row_prev):
+        assert row.is_write == 1
+
+    # 2. stack_ptr in range
+    stack_ptr = get_stack_ptr(row)
+    assert_in_range(stack_ptr, 0, MAX_STACK_PTR)
+
+    # 3. stack_ptr only increases by 0 or 1
+    if row.tag() == row_prev.tag() and get_call_id(row) == get_call_id(row_prev):
+        stack_ptr_diff = get_stack_ptr(row) - get_stack_ptr(row_prev)
+        assert_in_range(stack_ptr_diff, 0, 1)
+
+
+@is_circuit_code
+def check_storage(row: Row, row_prev: Row):
+    get_addr = lambda row: row.keys[2]
+    get_storage_key = lambda row: row.keys[4]
+
+    # TODO: cold VS warm
+    # TODO: connection to MPT on first and last access for each (address, key)
+
+    # 0. Unused keys are 0
+    assert row.keys[1] == 0
+    assert row.keys[3] == 0
+
+    # 1. First access for a set of all keys
+    #
+    # We add an extra write to set the value of the state in previous block, with rwc=0.
+    #
+    # When the set of all keys changes (first access of storage (address, key))
+    # - It must be a WRITE
+    if not all_keys_eq(row, row_prev):
+        assert row.is_write == 1 and row.rw_counter == 0
+
+
+@is_circuit_code
+def check_call_context(row: Row, row_prev: Row):
+    get_call_id = lambda row: row.keys[1]
+    get_field_tag = lambda row: row.keys[3]
+
+    # 0. Unused keys are 0
+    assert row.keys[2] == 0
+    assert row.keys[4] == 0
+
+    # TODO: Missing constraints
+
+
+@is_circuit_code
+def check_account(row: Row, row_prev: Row):
+    get_addr = lambda row: row.keys[2]
+    get_field_tag = lambda row: row.keys[3]
+
+    # 0. Unused keys are 0
+    assert row.keys[1] == 0
+    assert row.keys[4] == 0
+
+    # 1. First access for a set of all keys
+    #
+    # We add an extra write to setup the value of the previous block, with rwc=0.
+    #
+    # When the set of all keys changes (first access of storage (address, AccountFieldTag))
+    # - It must be a WRITE
+    if not all_keys_eq(row, row_prev):
+        assert row.is_write == 1 and row.rw_counter == 0
+
+    # NOTE: Value transition rules are constrained via the EVM circuit: for example,
+    # Nonce only increases by 1 or decreases by 1 (on revert).
+
+
+@is_circuit_code
+def check_tx_refund(row: Row, row_prev: Row):
+    get_tx_id = lambda row: row.keys[1]
+
+    # 0. Unused keys are 0
+    assert row.keys[2] == 0
+    assert row.keys[3] == 0
+    assert row.keys[4] == 0
+
+    # TODO: Missing constraints
+
+
+@is_circuit_code
+def check_tx_access_list_account(row: Row, row_prev: Row):
+    get_tx_id = lambda row: row.keys[1]
+    get_addr = lambda row: row.keys[2]
+
+    # 0. Unused keys are 0
+    assert row.keys[3] == 0
+    assert row.keys[4] == 0
+
+    # TODO: Missing constraints
+
+
+@is_circuit_code
+def check_tx_access_list_account_storage(row: Row, row_prev: Row):
+    get_tx_id = lambda row: row.keys[1]
+    get_addr = lambda row: row.keys[2]
+    get_storage_key = lambda row: row.keys[4]
+
+    # 0. Unused keys are 0
+    assert row.keys[3] == 0
+
+    # TODO: Missing constraints
+
+
+@is_circuit_code
+def check_account_destructed(row: Row, row_prev: Row):
+    get_addr = lambda row: row.keys[2]
+
+    # 0. Unused keys are 0
+    assert row.keys[1] == 0
+    assert row.keys[3] == 0
+    assert row.keys[4] == 0
+
+    # TODO: Missing constraints
+
+
+@is_circuit_code
+def check_state_row(row: Row, row_prev: Row, randomness: FQ):
+    #
+    # Constraints that affect all rows, no matter which Tag they use
+    #
+
+    # 0. key0, key1, key3 are in the expected range
+    assert_in_range(row.keys[0], 0, MAX_KEY0)
+    assert_in_range(row.keys[1], 0, MAX_KEY1)
+    assert_in_range(row.keys[3], 0, MAX_KEY3)
+
+    # 1. key2 is linear combination of 10 x 16bit limbs and also in range
+    for limb in row.key2_limbs:
+        assert_in_range(limb, 0, 2**16 - 1)
+    assert row.keys[2] == linear_combine(row.key2_limbs, FQ(2**16))
+
+    # 2. key4 is RLC encoded
+    for limb in row.key4_bytes:
+        assert_in_range(limb, 0, 2**8 - 1)
+    assert row.keys[4] == linear_combine(row.key4_bytes, randomness)
+
+    # 3. is_write is boolean
+    assert row.is_write in [0, 1]
+
+    # 4. Keys are sorted in lexicographic order for same Tag
+    #
+    # This check also ensures that Tag monotonically increases for all values
+    # except for Start
+    #
+    # When in two consecutive rows the keys are equal in a column:
+    # - The corresponding keys in the following column must be increasing.
+    #
+    # key4 is RLC encoded, so it doesn't keep the order.  We use the key4 bytes
+    # decomposition instead.  Since we will use a chain of comparison gadgets,
+    # we try to merge multiple keys together to reduce the number of required
+    # gadgets.
+
+    # Assert that key0, key1, key2, key3, 4 bytes from key4 fit inside an element
+    assert KEY0_BITS + KEY1_BITS + KEY2_BITS + KEY3_BITS + 4 * 8 < log(FQ(-1).n + 1, 2)
+
+    def get_keys_compressed_in_order(row: Row) -> List[FQ]:
+        k0 = row.keys[0]
+        k0 = k0 * 2**KEY1_BITS + row.keys[1]
+        k0 = k0 * 2**KEY2_BITS + row.keys[2]
+        k0 = k0 * 2**KEY3_BITS + row.keys[3]
+        k0 = k0 * 2 ** (4 * 8) + linear_combine(row.key4_bytes[-4:], FQ(2**8))
+        k1 = linear_combine(row.key4_bytes[:-4], FQ(2**8))
+        return [k0, k1]
+
+    keys = get_keys_compressed_in_order(row)
+    keys_prev = get_keys_compressed_in_order(row_prev)
+    keys_eq = True
+    cmps = [ComparisonGadget(keys_prev[i], keys[i]) for i in range(len(keys))]
+    if row.tag() != Tag.Start:
+        assert cmps[0].lt or (cmps[0].eq and cmps[1].lt) or (cmps[0].eq and cmps[1].eq)
+
+    # 5. RWC is monotonically strictly increasing for a set of all keys
+    #
+    # When tag is not Start and all the keys are equal in two consecutive a rows:
+    # - The corresponding rwc must be strictly increasing.
+    if row.tag() != Tag.Start and all_keys_eq(row, row_prev):
+        rw_diff = row.rw_counter - row_prev.rw_counter
+        assert_in_range(rw_diff, 1, MAX_KEY_DIFF)
+
+    # 6. Read consistency
+    #
+    # When a row is READ
+    # AND When all the keys are equal in two consecutive a rows:
+    # - The corresponding value must be equal to the previous row
+    if row.is_write == 0 and all_keys_eq(row, row_prev):
+        assert row.value == row_prev.value
+
+    #
+    # Constraints specific to each Tag
+    #
+    if row.tag() == Tag.Start:
+        check_start(row, row_prev)
+    elif row.tag() == Tag.Memory:
+        check_memory(row, row_prev)
+    elif row.tag() == Tag.Stack:
+        check_stack(row, row_prev)
+    elif row.tag() == Tag.Storage:
+        check_storage(row, row_prev)
+    elif row.tag() == Tag.CallContext:
+        check_call_context(row, row_prev)
+    elif row.tag() == Tag.Account:
+        check_account(row, row_prev)
+    elif row.tag() == Tag.TxRefund:
+        check_tx_refund(row, row_prev)
+    elif row.tag() == Tag.TxAccessListAccountStorage:
+        check_tx_access_list_account_storage(row, row_prev)
+    elif row.tag() == Tag.TxAccessListAccount:
+        check_tx_access_list_account(row, row_prev)
+    elif row.tag() == Tag.AccountDestructed:
+        check_account_destructed(row, row_prev)
+    else:
+        raise ValueError("Unreacheable")
+
+
+# State circuit operation superclass
+class Operation(NamedTuple):
+    """
+    State circuit operation
+    """
+
+    rw_counter: int
+    rw: RW
+    key0: U256
+    key1: U256
+    key2: U256
+    key3: U256
+    key4: U256
+    value: FQ
+    aux0: FQ
+    aux1: FQ
+
+
+class StartOp(Operation):
+    """
+    Start Operation
+    """
+
+    def __new__(self):
+        # fmt: off
+        return super().__new__(self, 0, 0,
+                U256(Tag.Start), U256(0), U256(0), U256(0), U256(0), # keys
+                FQ(0), FQ(0), FQ(0)) # values
+        # fmt: on
+
+
+class MemoryOp(Operation):
+    """
+    Memory Operation
+    """
+
+    def __new__(self, rw_counter: int, rw: RW, call_id: int, mem_addr: int, value: U8):
+        # fmt: off
+        return super().__new__(self, rw_counter, rw,
+                U256(Tag.Memory), U256(call_id), U256(0), U256(mem_addr), U256(0), # keys
+                FQ(value), FQ(0), FQ(0)) # values
+        # fmt: on
+
+
+class StackOp(Operation):
+    """
+    Stack Operation
+    """
+
+    def __new__(self, rw_counter: int, rw: RW, call_id: int, stack_ptr: int, value: FQ):
+        # fmt: off
+        return super().__new__(self, rw_counter, rw,
+                U256(Tag.Stack), U256(call_id), U256(0), U256(stack_ptr), U256(0), # keys
+                value, FQ(0), FQ(0)) # values
+        # fmt: on
+
+
+class StorageOp(Operation):
+    """
+    Storage Operation
+    """
+
+    def __new__(self, rw_counter: int, rw: RW, addr: U160, key: U256, value: FQ):
+        # fmt: off
+        return super().__new__(self, rw_counter, rw,
+                U256(Tag.Storage), U256(0), U256(addr), U256(0), U256(key), # keys
+                value, FQ(0), FQ(0)) # values
+        # fmt: on
+
+
+class CallContextOp(Operation):
+    """
+    CallContext Operation
+    """
+
+    def __new__(
+        self, rw_counter: int, rw: RW, call_id: int, field_tag: CallContextFieldTag, value: FQ
+    ):
+        # fmt: off
+        return super().__new__(self, rw_counter, rw,
+                U256(Tag.CallContext), U256(call_id), U256(0), U256(field_tag), U256(0), # keys
+                value, FQ(0), FQ(0)) # values
+        # fmt: on
+
+
+class AccountOp(Operation):
+    """
+    Account Operation
+    """
+
+    def __new__(self, rw_counter: int, rw: RW, addr: U160, field_tag: AccountFieldTag, value: FQ):
+        # fmt: off
+        return super().__new__(self, rw_counter, rw,
+                U256(Tag.Account), U256(0), U256(addr), U256(field_tag), U256(0), # keys
+                value, FQ(0), FQ(0)) # values
+        # fmt: on
+
+
+class TxRefundOp(Operation):
+    """
+    TxRefund Operation
+    """
+
+    def __new__(self, rw_counter: int, rw: RW, tx_id: int, value: FQ):
+        # fmt: off
+        return super().__new__(self, rw_counter, rw,
+                U256(Tag.TxRefund), U256(tx_id), U256(0), U256(0), U256(0), # keys
+                value, FQ(0), FQ(0)) # values
+        # fmt: on
+
+
+class TxAccessListAccountOp(Operation):
+    """
+    TxAccessListAccount Operation
+    """
+
+    def __new__(self, rw_counter: int, rw: RW, tx_id: int, addr: U160, value: FQ):
+        # fmt: off
+        return super().__new__(self, rw_counter, rw,
+                U256(Tag.TxAccessListAccount), U256(tx_id), U256(addr), U256(0), U256(0), # keys
+                value, FQ(0), FQ(0)) # values
+        # fmt: on
+
+
+class TxAccessListAccountStorageOp(Operation):
+    """
+    TxAccessListAccountStorage Operation
+    """
+
+    def __new__(self, rw_counter: int, rw: RW, tx_id: int, addr: U160, key: U256, value: FQ):
+        # fmt: off
+        return super().__new__(self, rw_counter, rw,
+                U256(Tag.TxAccessListAccountStorage),
+                U256(tx_id), U256(addr), U256(0), U256(key), # keys
+                value, FQ(0), FQ(0)) # values
+        # fmt: on
+
+
+class AccountDestructedOp(Operation):
+    """
+    AccountDestructed Operation
+    """
+
+    def __new__(self, rw_counter: int, rw: RW, addr: U160, value: FQ):
+        # fmt: off
+        return super().__new__(self, rw_counter, rw,
+                U256(Tag.AccountDestructed), U256(0), U256(addr), U256(0), U256(0), # keys
+                value, FQ(0), FQ(0)) # values
+        # fmt: on
+
+
+def op2row(op: Operation, randomness: FQ) -> Row:
+    rw_counter = FQ(op.rw_counter)
+    is_write = FQ(0) if op.rw == RW.Read else FQ(1)
+    key0 = FQ(op.key0)
+    key1 = FQ(op.key1)
+    key2 = FQ(op.key2)
+    key2_bytes = op.key2.to_bytes(20, "little")
+    key2_limbs = tuple([FQ(key2_bytes[i] + 2**8 * key2_bytes[i + 1]) for i in range(0, 20, 2)])
+    key3 = FQ(op.key3)
+    key4_rlc = RLC(op.key4, randomness.n)
+    key4 = key4_rlc.value
+    key4_bytes = tuple([FQ(x) for x in key4_rlc.le_bytes])
+    value = FQ(op.value)
+    aux0 = FQ(op.aux0)
+    aux1 = FQ(op.aux1)
+
+    # fmt: off
+    return Row(rw_counter, is_write,
+            (key0, key1, key2, key3, key4), key2_limbs, key4_bytes, # keys
+            value, (aux0, aux1)) # values
+    # fmt: on
+
+
+# def rw_table_tag2tag(tag: RWTableTag) -> FQ:
+#     ret = None
+#     if tag == RWTableTag.Memory:
+#         ret = Tag.Memory
+#     elif tag == RWTableTag.Stack:
+#         ret = Tag.Stack
+#     elif tag == RWTableTag.Storage:
+#         ret = Tag.Storage
+#     elif tag == RWTableTag.CallContext:
+#         ret = Tag.CallContext
+#     elif tag == RWTableTag.Account:
+#         ret = Tag.Account
+#     elif tag == RWTableTag.TxRefund:
+#         ret = Tag.TxRefund
+#     elif tag == RWTableTag.TxAccessListAccount:
+#         ret = Tag.TxAccessListAccount
+#     elif tag == RWTableTag.TxAccessListAccountStorage:
+#         ret = Tag.TxAccessListAccountStorage
+#     elif tag == RWTableTag.AccountDestructed:
+#         ret = Tag.AccountDestructed
+#     else:
+#         raise ValueError("Unreacheable")
+#
+#     return FQ(ret)
+
+# Generate the advice Rows from a list of Operations
+def assign_state_circuit(ops: List[Operation], randomness: FQ) -> List[Row]:
+    rows = [op2row(op, randomness) for op in ops]
+    return rows

--- a/tests/test_state_circuit.py
+++ b/tests/test_state_circuit.py
@@ -1,0 +1,276 @@
+import traceback
+from typing import Union, List
+from zkevm_specs.state import *
+from zkevm_specs.util import rand_fp, FQ, RLC
+
+randomness = rand_fp()
+r = randomness
+
+# Verify the state circuit with the given data
+def verify(ops_or_rows: Union[List[Operation], List[Row]], randomness: FQ, success: bool = True):
+    rows = ops_or_rows
+    if isinstance(ops_or_rows[0], Operation):
+        rows = assign_state_circuit(ops_or_rows, randomness)
+    ok = True
+    for (idx, row) in enumerate(rows):
+        row_prev = rows[(idx - 1) % len(rows)]
+        try:
+            check_state_row(row, row_prev, randomness)
+        except AssertionError as e:
+            if success:
+                traceback.print_exc()
+            print(f"row[{(idx-1) % len(rows)}]: {row_prev}")
+            print(f"row[{idx}]: {row}")
+            ok = False
+            break
+    assert ok == success
+
+
+def test_state_ok():
+    # fmt: off
+    ops = [
+        StartOp(),
+        StartOp(),
+        StartOp(),
+
+        MemoryOp(rw_counter=1, rw=RW.Read,  call_id=1, mem_addr=0, value=0),
+        MemoryOp(rw_counter=2, rw=RW.Write, call_id=1, mem_addr=0, value=42),
+        MemoryOp(rw_counter=3, rw=RW.Read,  call_id=1, mem_addr=0, value=42),
+
+        StackOp(rw_counter=4, rw=RW.Write, call_id=1, stack_ptr=1022, value=RLC(4321 ,r).value),
+        StackOp(rw_counter=5, rw=RW.Write, call_id=1, stack_ptr=1023, value=RLC(533 ,r).value),
+        StackOp(rw_counter=6, rw=RW.Read,  call_id=1, stack_ptr=1023, value=RLC(533 ,r).value),
+
+        StorageOp(rw_counter=0, rw=RW.Write, addr=0x12345678, key=0x1516, value=RLC(789, r).value),
+        StorageOp(rw_counter=7, rw=RW.Read,  addr=0x12345678, key=0x1516, value=RLC(789, r).value),
+        StorageOp(rw_counter=0, rw=RW.Write, addr=0x12345678, key=0x4959, value=RLC(98765, r).value),
+        StorageOp(rw_counter=8, rw=RW.Write, addr=0x12345678, key=0x4959, value=RLC(38491, r).value),
+
+        CallContextOp(rw_counter= 9, rw=RW.Read, call_id=1, field_tag=CallContextFieldTag.IsStatic, value=FQ(0)),
+        CallContextOp(rw_counter=10, rw=RW.Read, call_id=2, field_tag=CallContextFieldTag.IsStatic, value=FQ(0)),
+
+        AccountOp(rw_counter= 0, rw=RW.Write, addr=0x12345678, field_tag=AccountFieldTag.Nonce, value=FQ(0)),
+        AccountOp(rw_counter=12, rw=RW.Write, addr=0x12345678, field_tag=AccountFieldTag.Nonce, value=FQ(1)),
+        AccountOp(rw_counter=13, rw=RW.Read,  addr=0x12345678, field_tag=AccountFieldTag.Nonce, value=FQ(1)),
+
+        TxRefundOp(rw_counter=14, rw=RW.Write, tx_id=1, value=FQ(1)),
+        TxRefundOp(rw_counter=15, rw=RW.Write, tx_id=1, value=FQ(1)),
+
+        TxAccessListAccountOp(rw_counter=16, rw=RW.Read, tx_id=1, addr=0x12345678, value=FQ(1)),
+        TxAccessListAccountOp(rw_counter=17, rw=RW.Read, tx_id=1, addr=0x12345678, value=FQ(1)),
+
+        TxAccessListAccountStorageOp(rw_counter=18, rw=RW.Read, tx_id=1, addr=0x12345678, key=0x1516, value=FQ(1)),
+        TxAccessListAccountStorageOp(rw_counter=19, rw=RW.Read, tx_id=1, addr=0x12345678, key=0x1516, value=FQ(1)),
+
+        AccountDestructedOp(rw_counter=20, rw=RW.Read, addr=0x12345678, value=FQ(1)),
+        AccountDestructedOp(rw_counter=21, rw=RW.Read, addr=0x12345678, value=FQ(1)),
+    ]
+    # fmt: on
+    verify(ops, randomness)
+
+
+def test_state_bad_key2():
+    # fmt: off
+    ops = [
+        StartOp(),
+        MemoryOp(rw_counter=1, rw=RW.Read,  call_id=2, mem_addr=123, value=0),
+    ]
+    # fmt: on
+    rows = assign_state_circuit(ops, r)
+    rows[1] = rows[1]._replace(key2_limbs=(FQ(1),) * 10)
+    verify(rows, randomness, success=False)
+
+
+def test_state_bad_key4():
+    # fmt: off
+    ops = [
+        StartOp(),
+        StorageOp(rw_counter=0, rw=RW.Write, addr=0x12345678, key=0x15161718, value=RLC(789, r).value),
+    ]
+    # fmt: on
+    rows = assign_state_circuit(ops, r)
+    rows[1] = rows[1]._replace(key4_bytes=(FQ(1),) * 10)
+    verify(rows, randomness, success=False)
+
+
+def test_state_bad_is_write():
+    # fmt: off
+    ops = [
+        StartOp(),
+        StorageOp(rw_counter=0, rw=RW.Write, addr=0x12345678, key=0x15161718, value=RLC(789, r).value),
+    ]
+    # fmt: on
+    rows = assign_state_circuit(ops, r)
+    rows[1] = rows[1]._replace(is_write=FQ(2))
+    verify(rows, randomness, success=False)
+
+
+def test_state_keys_non_lexicographic_order():
+    # fmt: off
+    ops = [
+        StartOp(),
+        StorageOp(rw_counter=0, rw=RW.Write, addr=0x12345678, key=0x1112, value=RLC(98765, r).value),
+        StorageOp(rw_counter=0, rw=RW.Write, addr=0x12345678, key=0x1111, value=RLC(789, r).value),
+    ]
+    # fmt: on
+    verify(ops, randomness, success=False)
+
+    # fmt: off
+    ops = [
+        StartOp(),
+        StorageOp(rw_counter=0, rw=RW.Write, addr=0x12345678, key=2 << 250, value=RLC(98765, r).value),
+        StorageOp(rw_counter=0, rw=RW.Write, addr=0x12345678, key=1 << 250, value=RLC(789, r).value),
+    ]
+    # fmt: on
+    verify(ops, randomness, success=False)
+
+    # fmt: off
+    ops = [
+        StartOp(),
+        StorageOp(rw_counter=0, rw=RW.Write, addr=0x12345678, key=123, value=RLC(98765, r).value),
+        StorageOp(rw_counter=1, rw=RW.Write, addr=0x12345678, key=123, value=RLC(789, r).value),
+        MemoryOp(rw_counter=2, rw=RW.Read,  call_id=1, mem_addr=0, value=0),
+    ]
+    # fmt: on
+    verify(ops, randomness, success=False)
+
+    # fmt: off
+    ops = [
+        StartOp(),
+        MemoryOp(rw_counter=1, rw=RW.Read,  call_id=2, mem_addr=0, value=0),
+        MemoryOp(rw_counter=2, rw=RW.Read,  call_id=1, mem_addr=0, value=0),
+    ]
+    # fmt: on
+    verify(ops, randomness, success=False)
+
+
+def test_state_bad_rwc():
+    # fmt: off
+    ops = [
+        StartOp(),
+        MemoryOp(rw_counter=2, rw=RW.Read,  call_id=2, mem_addr=123, value=0),
+        MemoryOp(rw_counter=1, rw=RW.Read,  call_id=2, mem_addr=123, value=0),
+    ]
+    # fmt: on
+    verify(ops, randomness, success=False)
+
+
+def test_state_bad_read_consisntency():
+    # fmt: off
+    ops = [
+        StartOp(),
+        MemoryOp(rw_counter=1, rw=RW.Read,  call_id=2, mem_addr=123, value=0),
+        MemoryOp(rw_counter=2, rw=RW.Write, call_id=2, mem_addr=123, value=8),
+        MemoryOp(rw_counter=3, rw=RW.Read,  call_id=2, mem_addr=123, value=0),
+    ]
+    # fmt: on
+    verify(ops, randomness, success=False)
+
+
+def test_start_bad():
+    # fmt: off
+    ops = [
+        StartOp(),
+        MemoryOp(rw_counter=1, rw=RW.Read,  call_id=2, mem_addr=123, value=0),
+    ]
+    # fmt: on
+    rows = assign_state_circuit(ops, r)
+    rows[0] = rows[0]._replace(rw_counter=FQ(1))
+    verify(rows, randomness, success=False)
+
+
+def test_memory_bad_first_access():
+    # fmt: off
+    ops = [
+        StartOp(),
+        MemoryOp(rw_counter=1, rw=RW.Read,  call_id=1, mem_addr=123, value=3),
+    ]
+    # fmt: on
+    verify(ops, randomness, success=False)
+
+
+def test_memory_bad_mem_addr_range():
+    # fmt: off
+    ops = [
+        StartOp(),
+        MemoryOp(rw_counter=1, rw=RW.Read,  call_id=1, mem_addr=2**32, value=3),
+    ]
+    # fmt: on
+    verify(ops, randomness, success=False)
+
+
+def test_memory_bad_value_range():
+    # fmt: off
+    ops = [
+        StartOp(),
+        MemoryOp(rw_counter=1, rw=RW.Read,  call_id=1, mem_addr=123, value=256),
+    ]
+    # fmt: on
+    verify(ops, randomness, success=False)
+
+
+def test_stack_bad_first_access():
+    # fmt: off
+    ops = [
+        StartOp(),
+        StackOp(rw_counter=1, rw=RW.Read, call_id=1, stack_ptr=1023, value=RLC(4321 ,r).value),
+    ]
+    # fmt: on
+    verify(ops, randomness, success=False)
+
+
+def test_stack_bad_stack_ptr_range():
+    # fmt: off
+    ops = [
+        StartOp(),
+        StackOp(rw_counter=1, rw=RW.Write, call_id=1, stack_ptr=1024, value=RLC(4321 ,r).value),
+    ]
+    # fmt: on
+    verify(ops, randomness, success=False)
+
+
+def test_stack_bad_stack_ptr_inc():
+    # fmt: off
+    ops = [
+        StartOp(),
+        StackOp(rw_counter=1, rw=RW.Write, call_id=1, stack_ptr=1021, value=RLC(4321 ,r).value),
+        StackOp(rw_counter=2, rw=RW.Write, call_id=1, stack_ptr=1023, value=RLC(4321 ,r).value),
+    ]
+    # fmt: on
+    verify(ops, randomness, success=False)
+
+
+def test_storage_bad_first_access():
+    # fmt: off
+    ops = [
+        StartOp(),
+        StorageOp(rw_counter=0, rw=RW.Read, addr=0x12345678, key=0x1516, value=RLC(789, r).value),
+    ]
+    # fmt: on
+    verify(ops, randomness, success=False)
+
+    # fmt: off
+    ops = [
+        StartOp(),
+        StorageOp(rw_counter=1, rw=RW.Write, addr=0x12345678, key=0x1516, value=RLC(789, r).value),
+    ]
+    # fmt: on
+    verify(ops, randomness, success=False)
+
+
+def test_account_bad_first_access():
+    # fmt: off
+    ops = [
+        StartOp(),
+        AccountOp(rw_counter= 0, rw=RW.Read, addr=0x12345678, field_tag=AccountFieldTag.Nonce, value=FQ(0)),
+    ]
+    # fmt: on
+    verify(ops, randomness, success=False)
+
+    # fmt: off
+    ops = [
+        StartOp(),
+        AccountOp(rw_counter=1, rw=RW.Write, addr=0x12345678, field_tag=AccountFieldTag.Nonce, value=FQ(0)),
+    ]
+    # fmt: on
+    verify(ops, randomness, success=False)


### PR DESCRIPTION
- Update the state proof document
- Write the spec of the state circuit in python from scratch following
  the current `rw_table` design.
- Add a minimal state circuit test
- List of changes:
    - Renamed key and aux columns so start with index 0, in order to
      make it more readable when working with code were we have arrays
      called `keys`.  This way `key0` == `keys[0]`.
    - Add a new key column so that we have a cloumn exclusive for
      address keys, which allows us to reuse the key order constraints
      for addresses for all operations.
    - Add the boilerplate for the missing operations
    - Remove value2 column (used for `valuePrev`) in some Write
      operations