### PR TITLE
Add `mypy`

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -27,5 +27,7 @@ jobs:
         make install
     - name: Lint
       run: make lint
+    - name: Type check
+      run: make type
     - name: Test with pytest
       run: make test

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ lint: ## Check whether the code is formated correctly
 	black . --check
 	mdformat specs/ --number --check
 
+type: ## Check the typing of the Python code
+	mypy src
+
 test: ## Run tests
 	pytest
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,3 +31,4 @@ test =
 lint =
     black >= 22.1.0
     mdformat >= 0.7.13
+    mypy >= 0.931

--- a/src/zkevm_specs/__init__.py
+++ b/src/zkevm_specs/__init__.py
@@ -1,3 +1,4 @@
+from . import bytecode
 from . import encoding
 from . import evm
 from . import opcode

--- a/src/zkevm_specs/encoding/lookup.py
+++ b/src/zkevm_specs/encoding/lookup.py
@@ -2,7 +2,7 @@ from typing import Tuple, Sequence, Set
 
 
 class LookupTable:
-    columns: Tuple[str]
+    columns: Tuple[str, ...]
     rows: Set[Tuple[int, ...]]
 
     def __init__(self, columns: Sequence[str]) -> None:

--- a/src/zkevm_specs/encoding/utils.py
+++ b/src/zkevm_specs/encoding/utils.py
@@ -1,8 +1,8 @@
-from typing import Sequence, Tuple, List
+from typing import Sequence, Tuple
 from .typing import U8, U256, U64
 
 
-def is_circuit_code(func) -> object:
+def is_circuit_code(func):
     """
     A no-op decorator just to mark the function
     """
@@ -15,19 +15,19 @@ def is_circuit_code(func) -> object:
 
 def u256_to_u8s(x: U256) -> Tuple[U8, ...]:
     assert 0 <= x < 2**256, "expect x is unsigned 256 bits"
-    return tuple((x >> 8 * i) & 0xFF for i in range(32))
+    return tuple(U8((x >> 8 * i) & 0xFF) for i in range(32))
 
 
 def u256_to_u64s(x: U256) -> Tuple[U64, ...]:
     assert 0 <= x < 2**256, "expect x is unsigned 256 bits"
-    return tuple((x >> 64 * i) & 0xFFFFFFFFFFFFFFFF for i in range(4))
+    return tuple(U64((x >> 64 * i) & 0xFFFFFFFFFFFFFFFF) for i in range(4))
 
 
 def u8s_to_u256(xs: Sequence[U8]) -> U256:
     assert len(xs) == 32
     for u8 in xs:
         assert 0 <= u8 <= 255
-    return sum(x * (2 ** (8 * i)) for i, x in enumerate(xs))
+    return U256(sum(x * (2 ** (8 * i)) for i, x in enumerate(xs)))
 
 
 # [u8;32]->[u64;4]
@@ -37,5 +37,5 @@ def u8s_to_u64s(xs: Sequence[U8]) -> Tuple[U64, ...]:
     A = [u64_0] * 4  # A = A3A2A1A0
     for i in range(4):
         for j in range(8):
-            A[i] += U64(xs[j + 8 * i] * (2 ** (8 * j)))
+            A[i] += xs[j + 8 * i] * (2 ** (8 * j))
     return tuple(A)

--- a/src/zkevm_specs/evm/__init__.py
+++ b/src/zkevm_specs/evm/__init__.py
@@ -6,4 +6,4 @@ from .precompiled import *
 from .step import *
 from .table import *
 from .typing import *
-from . import util
+from .util import *

--- a/src/zkevm_specs/evm/execution/begin_tx.py
+++ b/src/zkevm_specs/evm/execution/begin_tx.py
@@ -1,6 +1,6 @@
-from ...util import GAS_COST_TX, GAS_COST_CREATION_TX, EMPTY_CODE_HASH
+from ...util import GAS_COST_TX, GAS_COST_CREATION_TX, EMPTY_CODE_HASH, FQ, RLC, cast_expr
 from ..execution_state import ExecutionState
-from ..instruction import Instruction, Transition
+from ..instruction import Instruction, ReversionInfo, Transition
 from ..precompiled import PrecompiledAddress
 from ..table import CallContextFieldTag, TxContextFieldTag, AccountFieldTag
 
@@ -9,28 +9,23 @@ def begin_tx(instruction: Instruction):
     call_id = instruction.curr.rw_counter
 
     tx_id = instruction.call_context_lookup(CallContextFieldTag.TxId, call_id=call_id)
-    rw_counter_end_of_reversion = instruction.call_context_lookup(
-        CallContextFieldTag.RwCounterEndOfReversion, call_id=call_id
-    )
-    is_persistent = instruction.call_context_lookup(
-        CallContextFieldTag.IsPersistent, call_id=call_id
-    )
+    reversion_info = instruction.reversion_info(call_id=call_id)
 
     if instruction.is_first_step:
-        instruction.constrain_equal(instruction.curr.rw_counter, 1)
-        instruction.constrain_equal(tx_id, 1)
+        instruction.constrain_equal(instruction.curr.rw_counter, FQ(1))
+        instruction.constrain_equal(tx_id, FQ(1))
 
     tx_caller_address = instruction.tx_context_lookup(tx_id, TxContextFieldTag.CallerAddress)
     tx_callee_address = instruction.tx_context_lookup(tx_id, TxContextFieldTag.CalleeAddress)
     tx_is_create = instruction.tx_context_lookup(tx_id, TxContextFieldTag.IsCreate)
-    tx_value = instruction.tx_context_lookup(tx_id, TxContextFieldTag.Value)
+    tx_value = cast_expr(instruction.tx_context_lookup(tx_id, TxContextFieldTag.Value), RLC)
     tx_call_data_length = instruction.tx_context_lookup(tx_id, TxContextFieldTag.CallDataLength)
 
     # Verify nonce
     tx_nonce = instruction.tx_context_lookup(tx_id, TxContextFieldTag.Nonce)
     nonce, nonce_prev = instruction.account_write(tx_caller_address, AccountFieldTag.Nonce)
     instruction.constrain_equal(tx_nonce, nonce_prev)
-    instruction.constrain_equal(nonce, nonce_prev + 1)
+    instruction.constrain_equal(nonce, nonce_prev.expr() + 1)
 
     # TODO: Implement EIP 1559 (currently it supports legacy transaction format)
     # Calculate gas fee
@@ -42,15 +37,19 @@ def begin_tx(instruction: Instruction):
     # TODO: Handle gas cost of tx level access list (EIP 2930)
     tx_call_data_gas_cost = instruction.tx_context_lookup(tx_id, TxContextFieldTag.CallDataGasCost)
     gas_left = (
-        tx_gas
+        tx_gas.expr()
         - (GAS_COST_CREATION_TX if tx_is_create == 1 else GAS_COST_TX)
-        - tx_call_data_gas_cost
+        - tx_call_data_gas_cost.expr()
     )
     instruction.constrain_gas_left_not_underflow(gas_left)
 
     # Prepare access list of caller and callee
-    instruction.constrain_equal(instruction.add_account_to_access_list(tx_id, tx_caller_address), 1)
-    instruction.constrain_equal(instruction.add_account_to_access_list(tx_id, tx_callee_address), 1)
+    instruction.constrain_equal(
+        instruction.add_account_to_access_list(tx_id, tx_caller_address), FQ(1)
+    )
+    instruction.constrain_equal(
+        instruction.add_account_to_access_list(tx_id, tx_callee_address), FQ(1)
+    )
 
     # Verify transfer
     instruction.transfer_with_gas_fee(
@@ -58,8 +57,7 @@ def begin_tx(instruction: Instruction):
         tx_callee_address,
         tx_value,
         gas_fee,
-        is_persistent,
-        rw_counter_end_of_reversion,
+        reversion_info,
     )
 
     if tx_is_create == 1:
@@ -79,16 +77,16 @@ def begin_tx(instruction: Instruction):
         # - TxId is checked from previous step or constraint to 1 if is_first_step
         # - IsSuccess, IsPersistent will be verified in the end of tx
         for (tag, value) in [
-            (CallContextFieldTag.Depth, 1),
+            (CallContextFieldTag.Depth, FQ(1)),
             (CallContextFieldTag.CallerAddress, tx_caller_address),
             (CallContextFieldTag.CalleeAddress, tx_callee_address),
-            (CallContextFieldTag.CallDataOffset, 0),
+            (CallContextFieldTag.CallDataOffset, FQ(0)),
             (CallContextFieldTag.CallDataLength, tx_call_data_length),
             (CallContextFieldTag.Value, tx_value),
-            (CallContextFieldTag.IsStatic, False),
-            (CallContextFieldTag.LastCalleeId, 0),
-            (CallContextFieldTag.LastCalleeReturnDataOffset, 0),
-            (CallContextFieldTag.LastCalleeReturnDataLength, 0),
+            (CallContextFieldTag.IsStatic, FQ(False)),
+            (CallContextFieldTag.LastCalleeId, FQ(0)),
+            (CallContextFieldTag.LastCalleeReturnDataOffset, FQ(0)),
+            (CallContextFieldTag.LastCalleeReturnDataLength, FQ(0)),
         ]:
             instruction.constrain_equal(
                 instruction.call_context_lookup(tag, call_id=call_id), value
@@ -104,9 +102,13 @@ def begin_tx(instruction: Instruction):
             state_write_counter=Transition.to(2),
         )
 
+        assert instruction.next is not None
+
         # Constrain either:
         # - is_empty_code and is_to_end_tx
         # - (not is_empty_code) and (not is_to_end_tx)
-        is_empty_code = instruction.is_equal(code_hash, instruction.int_to_rlc(EMPTY_CODE_HASH, 32))
+        is_empty_code = instruction.is_equal(
+            code_hash, RLC(EMPTY_CODE_HASH, instruction.randomness)
+        )
         is_to_end_tx = instruction.is_equal(instruction.next.execution_state, ExecutionState.EndTx)
         instruction.constrain_equal(is_empty_code + is_to_end_tx, 2 * is_empty_code * is_to_end_tx)

--- a/src/zkevm_specs/evm/execution/block_coinbase.py
+++ b/src/zkevm_specs/evm/execution/block_coinbase.py
@@ -1,3 +1,4 @@
+from ...util.param import N_BYTES_ACCOUNT_ADDRESS
 from ..instruction import Instruction, Transition
 from ..table import BlockContextFieldTag
 from ..opcode import Opcode
@@ -6,18 +7,14 @@ from ..opcode import Opcode
 def coinbase(instruction: Instruction):
     opcode = instruction.opcode_lookup(True)
     instruction.constrain_equal(opcode, Opcode.COINBASE)
-    address = instruction.stack_push()
+
     # in real circuit also check address raw data is 160 bit length (20 bytes)
     # check block table for coinbase address
     instruction.constrain_equal(
-        address,
-        instruction.int_to_rlc(
-            instruction.block_context_lookup(BlockContextFieldTag.Coinbase),
-            # NOTE: We can replace this with N_BYTES_WORD if we reuse the 32
-            # byte RLC constraint in all places.  See:
-            # https://github.com/appliedzkp/zkevm-specs/issues/101
-            20,
-        ),
+        instruction.block_context_lookup(BlockContextFieldTag.Coinbase),
+        # NOTE: We can replace this with N_BYTES_WORD if we reuse the 32 byte RLC constraint in
+        # all places. See: https://github.com/appliedzkp/zkevm-specs/issues/101
+        instruction.rlc_to_fq_exact(instruction.stack_push(), N_BYTES_ACCOUNT_ADDRESS),
     )
 
     instruction.step_state_transition_in_same_context(

--- a/src/zkevm_specs/evm/execution/block_timestamp.py
+++ b/src/zkevm_specs/evm/execution/block_timestamp.py
@@ -6,11 +6,11 @@ from ..opcode import Opcode
 def timestamp(instruction: Instruction):
     opcode = instruction.opcode_lookup(True)
     instruction.constrain_equal(opcode, Opcode.TIMESTAMP)
-    timestamp = instruction.stack_push()
+
     # check block table for timestamp
     instruction.constrain_equal(
-        timestamp,
-        instruction.int_to_rlc(instruction.block_context_lookup(BlockContextFieldTag.Timestamp), 8),
+        instruction.block_context_lookup(BlockContextFieldTag.Timestamp),
+        instruction.rlc_to_fq_exact(instruction.stack_push(), 8),
     )
 
     instruction.step_state_transition_in_same_context(

--- a/src/zkevm_specs/evm/execution/calldatacopy.py
+++ b/src/zkevm_specs/evm/execution/calldatacopy.py
@@ -1,24 +1,24 @@
-from ...util import N_BYTES_MEMORY_ADDRESS, FQ
+from ...util import N_BYTES_MEMORY_ADDRESS, FQ, Expression
 from ..execution_state import ExecutionState
 from ..instruction import Instruction, Transition
-from ..table import RW, FixedTableTag, RWTableTag, CallContextFieldTag, TxContextFieldTag
+from ..table import RW, CallContextFieldTag, TxContextFieldTag
 
 
 def calldatacopy(instruction: Instruction):
     opcode = instruction.opcode_lookup(True)
 
-    memory_offset = instruction.stack_pop()
-    data_offset = instruction.stack_pop()
-    length = instruction.stack_pop()
+    memory_offset_word = instruction.stack_pop()
+    data_offset_word = instruction.stack_pop()
+    length_word = instruction.stack_pop()
 
     # convert rlc to FQ
-    memory_offset, length = instruction.memory_offset_and_length(memory_offset, length)
-    data_offset = instruction.rlc_to_fq_exact(data_offset, N_BYTES_MEMORY_ADDRESS)
+    memory_offset, length = instruction.memory_offset_and_length(memory_offset_word, length_word)
+    data_offset = instruction.rlc_to_fq_exact(data_offset_word, N_BYTES_MEMORY_ADDRESS)
 
     tx_id = instruction.call_context_lookup(CallContextFieldTag.TxId, RW.Read)
     if instruction.curr.is_root:
         call_data_length = instruction.tx_context_lookup(tx_id, TxContextFieldTag.CallDataLength)
-        call_data_offset = FQ.zero()
+        call_data_offset: Expression = FQ.zero()
     else:
         call_data_length = instruction.call_context_lookup(
             CallContextFieldTag.CallDataLength, RW.Read
@@ -34,12 +34,15 @@ def calldatacopy(instruction: Instruction):
 
     # When length != 0, constrain the state in the next execution state CopyToMemory
     if not instruction.is_zero(length):
+        assert instruction.next is not None
         instruction.constrain_equal(instruction.next.execution_state, ExecutionState.CopyToMemory)
         next_aux = instruction.next.aux_data
         instruction.constrain_equal(next_aux.src_addr, data_offset + call_data_offset)
         instruction.constrain_equal(next_aux.dst_addr, memory_offset)
-        instruction.constrain_equal(next_aux.src_addr_end, call_data_length + call_data_offset)
-        instruction.constrain_equal(next_aux.from_tx, instruction.curr.is_root)
+        instruction.constrain_equal(
+            next_aux.src_addr_end, call_data_length.expr() + call_data_offset
+        )
+        instruction.constrain_equal(next_aux.from_tx, FQ(instruction.curr.is_root))
         instruction.constrain_equal(next_aux.tx_id, tx_id)
 
     instruction.step_state_transition_in_same_context(

--- a/src/zkevm_specs/evm/execution/calldataload.py
+++ b/src/zkevm_specs/evm/execution/calldataload.py
@@ -1,8 +1,8 @@
+from ...util import FQ, RLC, Expression, N_BYTES_WORD
 from ..instruction import Instruction, Transition
 from ..opcode import Opcode
 from ..table import RW, CallContextFieldTag, TxContextFieldTag
 from ..util import BufferReaderGadget
-from ...util.param import N_BYTES_WORD
 
 
 def calldataload(instruction: Instruction):
@@ -16,37 +16,36 @@ def calldataload(instruction: Instruction):
 
     if instruction.curr.is_root:
         calldata_length = instruction.tx_context_lookup(tx_id, TxContextFieldTag.CallDataLength)
-        calldata_offset = 0
+        calldata_offset: Expression = FQ(0)
     else:
         calldata_length = instruction.call_context_lookup(CallContextFieldTag.CallDataLength)
         calldata_offset = instruction.call_context_lookup(CallContextFieldTag.CallDataOffset)
         caller_id = instruction.call_context_lookup(CallContextFieldTag.CallerId)
 
     src_addr = offset + calldata_offset
-    src_addr_end = calldata_length + calldata_offset
+    src_addr_end = calldata_length.expr() + calldata_offset.expr()
 
     buffer_reader = BufferReaderGadget(
-        instruction, N_BYTES_WORD, src_addr, src_addr_end, N_BYTES_WORD
+        instruction, N_BYTES_WORD, src_addr, src_addr_end, FQ(N_BYTES_WORD)
     )
 
     calldata_word = []
     for idx in range(N_BYTES_WORD):
-        if buffer_reader.read_flag(idx):
+        if buffer_reader.read_flag(idx) == FQ(1):
             if instruction.curr.is_root:
                 tx_byte = instruction.tx_calldata_lookup(tx_id, src_addr + idx)
                 buffer_reader.constrain_byte(idx, tx_byte)
-                calldata_word.append(int(tx_byte))
+                calldata_word.append(tx_byte.expr().n)
             else:
                 mem_byte = instruction.memory_lookup(RW.Read, src_addr + idx, caller_id)
                 buffer_reader.constrain_byte(idx, mem_byte)
-                calldata_word.append(int(mem_byte))
+                calldata_word.append(mem_byte.expr().n)
         else:
-            buffer_reader.constrain_byte(idx, 0)
             calldata_word.append(0)
 
     instruction.constrain_equal(
         instruction.stack_push(),
-        instruction.bytes_to_rlc(bytes(calldata_word)),
+        RLC(bytes(calldata_word), instruction.randomness),
     )
 
     instruction.step_state_transition_in_same_context(

--- a/src/zkevm_specs/evm/execution/calldatasize.py
+++ b/src/zkevm_specs/evm/execution/calldatasize.py
@@ -1,23 +1,20 @@
+from ...util import N_BYTES_MEMORY_ADDRESS
 from ..instruction import Instruction, Transition
 from ..table import CallContextFieldTag
 from ..opcode import Opcode
-from ...util.param import N_BYTES_MEMORY_ADDRESS
 
 
 def calldatasize(instruction: Instruction):
     opcode = instruction.opcode_lookup(True)
+    instruction.constrain_equal(opcode, Opcode.CALLDATASIZE)
 
     # check [rw_table, call_context] table for call data length and compare
     # against stack top after push.
     instruction.constrain_equal(
-        instruction.int_to_rlc(
-            instruction.call_context_lookup(CallContextFieldTag.CallDataLength),
-            # NOTE: We can replace this with N_BYTES_WORD if we reuse the 32
-            # byte RLC constraint in all places.  See:
-            # https://github.com/appliedzkp/zkevm-specs/issues/101
-            N_BYTES_MEMORY_ADDRESS,
-        ),
-        instruction.stack_push(),
+        instruction.call_context_lookup(CallContextFieldTag.CallDataLength),
+        # NOTE: We can replace this with N_BYTES_WORD if we reuse the 32 byte RLC constraint in
+        # all places. See: https://github.com/appliedzkp/zkevm-specs/issues/101
+        instruction.rlc_to_fq_exact(instruction.stack_push(), N_BYTES_MEMORY_ADDRESS),
     )
 
     instruction.step_state_transition_in_same_context(

--- a/src/zkevm_specs/evm/execution/caller.py
+++ b/src/zkevm_specs/evm/execution/caller.py
@@ -1,7 +1,7 @@
+from ...util import N_BYTES_ACCOUNT_ADDRESS
 from ..instruction import Instruction, Transition
 from ..table import CallContextFieldTag
 from ..opcode import Opcode
-from ...util.param import N_BYTES_ACCOUNT_ADDRESS
 
 
 def caller(instruction: Instruction):
@@ -11,14 +11,10 @@ def caller(instruction: Instruction):
     # check [rw_table, call_context] table for caller address and compare with
     # stack top after push
     instruction.constrain_equal(
-        instruction.int_to_rlc(
-            instruction.call_context_lookup(CallContextFieldTag.CallerAddress),
-            # NOTE: We can replace this with N_BYTES_WORD if we reuse the 32
-            # byte RLC constraint in all places.  See:
-            # https://github.com/appliedzkp/zkevm-specs/issues/101
-            N_BYTES_ACCOUNT_ADDRESS,
-        ),
-        instruction.stack_push(),
+        instruction.call_context_lookup(CallContextFieldTag.CallerAddress),
+        # NOTE: We can replace this with N_BYTES_WORD if we reuse the 32 byte RLC constraint in
+        # all places. See: https://github.com/appliedzkp/zkevm-specs/issues/101
+        instruction.rlc_to_fq_exact(instruction.stack_push(), N_BYTES_ACCOUNT_ADDRESS),
     )
 
     instruction.step_state_transition_in_same_context(

--- a/src/zkevm_specs/evm/execution/end_block.py
+++ b/src/zkevm_specs/evm/execution/end_block.py
@@ -1,3 +1,4 @@
+from ...util import FQ
 from ..instruction import Instruction, Transition
 from ..table import CallContextFieldTag
 
@@ -12,7 +13,7 @@ def end_block(instruction: Instruction):
         total_tx = instruction.call_context_lookup(CallContextFieldTag.TxId)
         instruction.constrain_equal(
             total_tx,
-            max([tx_id for tx_id, *_ in instruction.tables.tx_table]),
+            FQ(max([row.tx_id.expr().n for row in instruction.tables.tx_table])),
         )
 
         # Verify rw_counter counts to identical rw amount in rw_table to ensure
@@ -20,7 +21,7 @@ def end_block(instruction: Instruction):
         total_rw = instruction.curr.rw_counter + 1  # extra 1 from the tx_id lookup
         instruction.constrain_equal(
             total_rw,
-            len(instruction.tables.rw_table),
+            FQ(len(instruction.tables.rw_table)),
         )
     else:
         # Propagate rw_counter and call_id all the way down

--- a/src/zkevm_specs/evm/execution/end_tx.py
+++ b/src/zkevm_specs/evm/execution/end_tx.py
@@ -1,4 +1,4 @@
-from ...util import N_BYTES_GAS, MAX_REFUND_QUOTIENT_OF_GAS_USED
+from ...util import N_BYTES_GAS, MAX_REFUND_QUOTIENT_OF_GAS_USED, FQ, RLC, cast_expr
 from ..execution_state import ExecutionState
 from ..instruction import Instruction, Transition
 from ..table import BlockContextFieldTag, CallContextFieldTag, TxContextFieldTag
@@ -11,7 +11,7 @@ def end_tx(instruction: Instruction):
     tx_gas = instruction.tx_context_lookup(tx_id, TxContextFieldTag.Gas)
     gas_used = tx_gas - instruction.curr.gas_left
     max_refund, _ = instruction.constant_divmod(
-        gas_used, MAX_REFUND_QUOTIENT_OF_GAS_USED, N_BYTES_GAS
+        gas_used, FQ(MAX_REFUND_QUOTIENT_OF_GAS_USED), N_BYTES_GAS
     )
     refund = instruction.tx_refund_read(tx_id)
     effective_refund = instruction.min(max_refund, refund, 8)
@@ -26,28 +26,28 @@ def end_tx(instruction: Instruction):
     instruction.add_balance(tx_caller_address, [value])
 
     # Add gas_used * effective_tip to coinbase's balance
-    base_fee = instruction.block_context_lookup(BlockContextFieldTag.BaseFee)
+    base_fee = cast_expr(instruction.block_context_lookup(BlockContextFieldTag.BaseFee), RLC)
     effective_tip, _ = instruction.sub_word(tx_gas_price, base_fee)
     reward, carry = instruction.mul_word_by_u64(effective_tip, gas_used)
     instruction.constrain_zero(carry)
     coinbase = instruction.block_context_lookup(BlockContextFieldTag.Coinbase)
     instruction.add_balance(coinbase, [reward])
 
-    # Go to next transaction
+    assert instruction.next is not None
+
+    # When to next transaction
     if instruction.next.execution_state == ExecutionState.BeginTx:
         # Check next tx_id is increased by 1
         instruction.constrain_equal(
             instruction.call_context_lookup(
                 CallContextFieldTag.TxId, call_id=instruction.next.rw_counter
             ),
-            tx_id + 1,
+            tx_id.expr() + 1,
         )
-
         # Do step state transition for rw_counter
         instruction.constrain_step_state_transition(rw_counter=Transition.delta(5))
-    # Go to end of block
-    elif instruction.next.execution_state == ExecutionState.EndBlock:
+
+    # When to end of block
+    if instruction.next.execution_state == ExecutionState.EndBlock:
         # Do step state transition for rw_counter
         instruction.constrain_step_state_transition(rw_counter=Transition.delta(4))
-    else:
-        raise ValueError("Unreacheable")

--- a/src/zkevm_specs/evm/execution/gas.py
+++ b/src/zkevm_specs/evm/execution/gas.py
@@ -1,6 +1,6 @@
+from ...util import N_BYTES_GAS
 from ..instruction import Instruction, Transition
 from ..opcode import Opcode
-from ..table import CallContextFieldTag, TxContextFieldTag
 
 
 def gas(instruction: Instruction):
@@ -8,8 +8,7 @@ def gas(instruction: Instruction):
     instruction.constrain_equal(opcode, Opcode.GAS)
 
     # fetch gas from rw table and consider only the lower 8 bytes (uint64)
-    gas = instruction.rlc_to_le_bytes(instruction.stack_push())
-    gas = int.from_bytes(gas[0:8], "little")
+    gas = instruction.rlc_to_fq_exact(instruction.stack_push(), N_BYTES_GAS)
 
     instruction.constrain_equal(
         gas,

--- a/src/zkevm_specs/evm/execution/jump.py
+++ b/src/zkevm_specs/evm/execution/jump.py
@@ -15,7 +15,6 @@ def jump(instruction: Instruction):
     dest_value = instruction.rlc_to_fq_exact(dest, N_BYTES_PROGRAM_COUNTER)
 
     # Verify `dest` is code within byte code table
-    # assert Opcode.JUMPDEST == instruction.opcode_lookup_at(dest_value, True)
     instruction.constrain_equal(Opcode.JUMPDEST, instruction.opcode_lookup_at(dest_value, True))
 
     instruction.step_state_transition_in_same_context(

--- a/src/zkevm_specs/evm/execution/jumpi.py
+++ b/src/zkevm_specs/evm/execution/jumpi.py
@@ -1,4 +1,4 @@
-from ...util.param import N_BYTES_PROGRAM_COUNTER
+from ...util import FQ, N_BYTES_PROGRAM_COUNTER
 from ..instruction import Instruction, Transition
 from ..opcode import Opcode
 
@@ -14,7 +14,7 @@ def jumpi(instruction: Instruction):
 
     # check `cond` is zero or not
     if instruction.is_zero(cond):
-        pc_diff = 1
+        pc_diff = FQ(1)
     else:
         # Get `dest` raw value in max 8 bytes
         dest_value = instruction.rlc_to_fq_exact(dest, N_BYTES_PROGRAM_COUNTER)

--- a/src/zkevm_specs/evm/execution/memory_copy.py
+++ b/src/zkevm_specs/evm/execution/memory_copy.py
@@ -1,8 +1,8 @@
-from ...util import FQ, N_BYTES_MEMORY_SIZE
+from ...util import N_BYTES_MEMORY_SIZE, FQ, Expression
 from ..execution_state import ExecutionState
 from ..instruction import Instruction, Transition
 from ..step import CopyToMemoryAuxData
-from ..table import RW, TxContextFieldTag
+from ..table import RW
 from ..util import BufferReaderGadget
 
 
@@ -17,19 +17,15 @@ def copy_to_memory(instruction: Instruction):
         instruction, MAX_COPY_BYTES, aux.src_addr, aux.src_addr_end, aux.bytes_left
     )
 
-    data = []
-    rw_counter_delta = 0
     for i in range(MAX_COPY_BYTES):
-        if not buffer_reader.read_flag(i):
-            byte = FQ.zero()
+        if buffer_reader.read_flag(i) == 0:
+            byte: Expression = FQ(0)
         elif aux.from_tx == 1:
-            byte = instruction.tx_context_lookup(
-                aux.tx_id, TxContextFieldTag.CallData, aux.src_addr + i
-            )
+            byte = instruction.tx_calldata_lookup(aux.tx_id, aux.src_addr + i)
         else:
             byte = instruction.memory_lookup(RW.Read, aux.src_addr + i)
         buffer_reader.constrain_byte(i, byte)
-        if buffer_reader.has_data(i):
+        if buffer_reader.has_data(i) == 1:
             instruction.constrain_equal(byte, instruction.memory_lookup(RW.Write, aux.dst_addr + i))
 
     copied_bytes = buffer_reader.num_bytes()
@@ -38,9 +34,12 @@ def copy_to_memory(instruction: Instruction):
     instruction.constrain_zero((1 - lt) * (1 - finished))
 
     if finished == 0:
-        instruction.constrain_equal(instruction.next.execution_state, ExecutionState.CopyToMemory)
+        assert instruction.next is not None
         next_aux = instruction.next.aux_data
-        assert next_aux is not None and isinstance(next_aux, CopyToMemoryAuxData)
+
+        assert isinstance(next_aux, CopyToMemoryAuxData)
+
+        instruction.constrain_equal(instruction.next.execution_state, ExecutionState.CopyToMemory)
         instruction.constrain_equal(next_aux.src_addr, aux.src_addr + copied_bytes)
         instruction.constrain_equal(next_aux.dst_addr, aux.dst_addr + copied_bytes)
         instruction.constrain_equal(next_aux.bytes_left + copied_bytes, aux.bytes_left)

--- a/src/zkevm_specs/evm/execution/origin.py
+++ b/src/zkevm_specs/evm/execution/origin.py
@@ -1,7 +1,7 @@
+from ...util import N_BYTES_ACCOUNT_ADDRESS
 from ..instruction import Instruction, Transition
 from ..opcode import Opcode
 from ..table import CallContextFieldTag, TxContextFieldTag
-from ...util.param import N_BYTES_ACCOUNT_ADDRESS
 
 
 def origin(instruction: Instruction):
@@ -11,11 +11,8 @@ def origin(instruction: Instruction):
     instruction.constrain_equal(opcode, Opcode.ORIGIN)
 
     instruction.constrain_equal(
-        instruction.int_to_rlc(
-            instruction.tx_context_lookup(tx_id, TxContextFieldTag.CallerAddress),
-            N_BYTES_ACCOUNT_ADDRESS,
-        ),
-        instruction.stack_push(),
+        instruction.tx_context_lookup(tx_id, TxContextFieldTag.CallerAddress),
+        instruction.rlc_to_fq_exact(instruction.stack_push(), N_BYTES_ACCOUNT_ADDRESS),
     )
 
     instruction.step_state_transition_in_same_context(

--- a/src/zkevm_specs/evm/execution/push.py
+++ b/src/zkevm_specs/evm/execution/push.py
@@ -1,3 +1,4 @@
+from ...util import FQ
 from ..instruction import Instruction, Transition
 from ..opcode import Opcode
 
@@ -8,17 +9,16 @@ def push(instruction: Instruction):
     num_additional_pushed = num_pushed - 1
 
     value = instruction.stack_push()
-    value_le_bytes = instruction.rlc_to_le_bytes(value)
     selectors = instruction.continuous_selectors(num_additional_pushed, 31)
 
     for idx in range(32):
         index = instruction.curr.program_counter + num_pushed - idx
-        if idx == 0 or selectors[idx - 1]:
+        if idx == 0 or selectors[idx - 1] == 1:
             instruction.constrain_equal(
-                value_le_bytes[idx], instruction.opcode_lookup_at(index, False)
+                FQ(value.le_bytes[idx]), instruction.opcode_lookup_at(index, False)
             )
         else:
-            instruction.constrain_zero(value_le_bytes[idx])
+            instruction.constrain_zero(FQ(value.le_bytes[idx]))
 
     instruction.step_state_transition_in_same_context(
         opcode,

--- a/src/zkevm_specs/evm/execution_state.py
+++ b/src/zkevm_specs/evm/execution_state.py
@@ -1,12 +1,13 @@
 from enum import IntEnum, auto
 from typing import Sequence, Tuple, Union
 
+from ..util import FQ
 from .opcode import (
     Opcode,
     invalid_opcodes,
-    state_write_opcodes,
-    stack_underflow_pairs,
     stack_overflow_pairs,
+    stack_underflow_pairs,
+    state_write_opcodes,
 )
 
 
@@ -139,6 +140,9 @@ class ExecutionState(IntEnum):
     ErrorOutOfGasSELFDESTRUCT = auto()
 
     # TODO: Precompile success and error cases
+
+    def expr(self) -> FQ:
+        return FQ(self)
 
     def responsible_opcode(self) -> Union[Sequence[int], Sequence[Tuple[int, int]]]:
         if self == ExecutionState.STOP:
@@ -378,17 +382,17 @@ class ExecutionState(IntEnum):
             return state_write_opcodes()
         return []
 
-    def halts(self):
+    def halts(self) -> bool:
         return self.halts_in_success() or self.halts_in_exception() or self == ExecutionState.REVERT
 
-    def halts_in_success(self):
+    def halts_in_success(self) -> bool:
         return self in [
             ExecutionState.STOP,
             ExecutionState.RETURN,
             ExecutionState.SELFDESTRUCT,
         ]
 
-    def halts_in_exception(self):
+    def halts_in_exception(self) -> bool:
         return self in [
             ExecutionState.ErrorInvalidOpcode,
             ExecutionState.ErrorStack,

--- a/src/zkevm_specs/evm/main.py
+++ b/src/zkevm_specs/evm/main.py
@@ -15,12 +15,8 @@ def verify_steps(
     begin_with_first_step: bool = False,
     end_with_last_step: bool = False,
 ):
-    # For the last step, the next step is meaningless
-    if end_with_last_step:
-        steps += [None]
-
-    for idx in range(len(steps) - 1):
-        curr, next = steps[idx], steps[idx + 1]
+    for idx in range(len(steps) - 1 + end_with_last_step):
+        curr, next = steps[idx], None if len(steps) == idx + 1 else steps[idx + 1]
 
         verify_step(
             Instruction(

--- a/src/zkevm_specs/evm/opcode.py
+++ b/src/zkevm_specs/evm/opcode.py
@@ -1,6 +1,7 @@
 from enum import IntEnum
-from typing import Final, Dict, List, Tuple
+from typing import Final, Dict, Tuple, List
 
+from ..util import FQ
 from ..util.param import *
 
 
@@ -147,6 +148,9 @@ class Opcode(IntEnum):
     STATICCALL = 0xFA
     REVERT = 0xFD
     SELFDESTRUCT = 0xFF
+
+    def expr(self) -> FQ:
+        return FQ(self)
 
     def hex(self) -> str:
         return "{:02x}".format(self)

--- a/src/zkevm_specs/evm/step.py
+++ b/src/zkevm_specs/evm/step.py
@@ -1,4 +1,4 @@
-from typing import Any, Sequence
+from typing import Any
 from .execution_state import ExecutionState
 from ..util import FQ, RLC
 
@@ -40,7 +40,7 @@ class StepState:
     memory_size: FQ
     state_write_counter: FQ
 
-    # Auxilary witness data needed by gadgets
+    # Auxiliary witness data needed by gadgets
     aux_data: Any
 
     def __init__(
@@ -50,7 +50,7 @@ class StepState:
         call_id: int = 0,
         is_root: bool = False,
         is_create: bool = False,
-        code_source: int = 0,
+        code_source: RLC = RLC(0),
         program_counter: int = 0,
         stack_pointer: int = 1024,
         gas_left: int = 0,

--- a/src/zkevm_specs/evm/typing.py
+++ b/src/zkevm_specs/evm/typing.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Any, Dict, Iterator, NewType, Optional, Sequence
+from typing import Dict, Iterator, List, NewType, Optional, Sequence, Union
 from functools import reduce
 from itertools import chain
 
@@ -7,14 +7,26 @@ from ..util import (
     U64,
     U160,
     U256,
-    Array3,
-    Array4,
+    FQ,
+    IntOrFQ,
     RLC,
+    Expression,
     keccak256,
     GAS_COST_TX_CALL_DATA_PER_NON_ZERO_BYTE,
     GAS_COST_TX_CALL_DATA_PER_ZERO_BYTE,
 )
-from .table import BlockContextFieldTag, TxContextFieldTag
+from .table import (
+    RW,
+    AccountFieldTag,
+    BlockContextFieldTag,
+    BlockTableRow,
+    BytecodeTableRow,
+    CallContextFieldTag,
+    RWTableRow,
+    RWTableTag,
+    TxContextFieldTag,
+    TxTableRow,
+)
 from .opcode import get_push_size, Opcode
 
 
@@ -38,12 +50,12 @@ class Block:
 
     def __init__(
         self,
-        coinbase: U160 = 0x10,
-        gas_limit: U64 = int(15e6),
-        number: U256 = 0,
-        timestamp: U64 = 0,
-        difficulty: U256 = 0,
-        base_fee: U256 = int(1e9),
+        coinbase: U160 = U160(0x10),
+        gas_limit: U64 = U64(int(15e6)),
+        number: U256 = U256(0),
+        timestamp: U64 = U64(0),
+        difficulty: U256 = U256(0),
+        base_fee: U256 = U256(int(1e9)),
         history_hashes: Sequence[U256] = [],
     ) -> None:
         assert len(history_hashes) <= min(256, number)
@@ -56,16 +68,22 @@ class Block:
         self.base_fee = base_fee
         self.history_hashes = history_hashes
 
-    def table_assignments(self, randomness: int) -> Sequence[Array3]:
+    def table_assignments(self, randomness: FQ) -> List[BlockTableRow]:
         return [
-            (BlockContextFieldTag.Coinbase, 0, self.coinbase),
-            (BlockContextFieldTag.GasLimit, 0, self.gas_limit),
-            (BlockContextFieldTag.Number, 0, RLC(self.number, randomness)),
-            (BlockContextFieldTag.Timestamp, 0, self.timestamp),
-            (BlockContextFieldTag.Difficulty, 0, RLC(self.difficulty, randomness)),
-            (BlockContextFieldTag.BaseFee, 0, RLC(self.base_fee, randomness)),
+            BlockTableRow(FQ(BlockContextFieldTag.Coinbase), FQ(0), FQ(self.coinbase)),
+            BlockTableRow(FQ(BlockContextFieldTag.GasLimit), FQ(0), FQ(self.gas_limit)),
+            BlockTableRow(FQ(BlockContextFieldTag.Number), FQ(0), RLC(self.number, randomness)),
+            BlockTableRow(FQ(BlockContextFieldTag.Timestamp), FQ(0), FQ(self.timestamp)),
+            BlockTableRow(
+                FQ(BlockContextFieldTag.Difficulty), FQ(0), RLC(self.difficulty, randomness)
+            ),
+            BlockTableRow(FQ(BlockContextFieldTag.BaseFee), FQ(0), RLC(self.base_fee, randomness)),
         ] + [
-            (BlockContextFieldTag.HistoryHash, self.number - idx - 1, RLC(history_hash, randomness))
+            BlockTableRow(
+                FQ(BlockContextFieldTag.HistoryHash),
+                FQ(self.number - idx - 1),
+                RLC(history_hash, randomness),
+            )
             for idx, history_hash in enumerate(reversed(self.history_hashes))
         ]
 
@@ -83,12 +101,12 @@ class Transaction:
     def __init__(
         self,
         id: int = 1,
-        nonce: U64 = 0,
-        gas: U64 = 21000,
-        gas_price: U256 = int(2e9),
-        caller_address: U160 = 0,
-        callee_address: Optional[U160] = None,
-        value: U256 = 0,
+        nonce: U64 = U64(0),
+        gas: U64 = U64(21000),
+        gas_price: U256 = U256(int(2e9)),
+        caller_address: U160 = U160(0),
+        callee_address: U160 = None,
+        value: U256 = U256(0),
         call_data: bytes = bytes(),
     ) -> None:
         self.id = id
@@ -114,21 +132,52 @@ class Transaction:
             0,
         )
 
-    def table_assignments(self, randomness: int) -> Iterator[Array4]:
+    def table_assignments(self, randomness: FQ) -> Iterator[TxTableRow]:
         return chain(
             [
-                (self.id, TxContextFieldTag.Nonce, 0, self.nonce),
-                (self.id, TxContextFieldTag.Gas, 0, self.gas),
-                (self.id, TxContextFieldTag.GasPrice, 0, RLC(self.gas_price, randomness)),
-                (self.id, TxContextFieldTag.CallerAddress, 0, self.caller_address),
-                (self.id, TxContextFieldTag.CalleeAddress, 0, self.callee_address),
-                (self.id, TxContextFieldTag.IsCreate, 0, self.callee_address is None),
-                (self.id, TxContextFieldTag.Value, 0, RLC(self.value, randomness)),
-                (self.id, TxContextFieldTag.CallDataLength, 0, len(self.call_data)),
-                (self.id, TxContextFieldTag.CallDataGasCost, 0, self.call_data_gas_cost()),
+                TxTableRow(FQ(self.id), FQ(TxContextFieldTag.Nonce), FQ(0), FQ(self.nonce)),
+                TxTableRow(FQ(self.id), FQ(TxContextFieldTag.Gas), FQ(0), FQ(self.gas)),
+                TxTableRow(
+                    FQ(self.id),
+                    FQ(TxContextFieldTag.GasPrice),
+                    FQ(0),
+                    RLC(self.gas_price, randomness),
+                ),
+                TxTableRow(
+                    FQ(self.id), FQ(TxContextFieldTag.CallerAddress), FQ(0), FQ(self.caller_address)
+                ),
+                TxTableRow(
+                    FQ(self.id),
+                    FQ(TxContextFieldTag.CalleeAddress),
+                    FQ(0),
+                    FQ(0 if self.callee_address is None else self.callee_address),
+                ),
+                TxTableRow(
+                    FQ(self.id),
+                    FQ(TxContextFieldTag.IsCreate),
+                    FQ(0),
+                    FQ(self.callee_address is None),
+                ),
+                TxTableRow(
+                    FQ(self.id), FQ(TxContextFieldTag.Value), FQ(0), RLC(self.value, randomness)
+                ),
+                TxTableRow(
+                    FQ(self.id),
+                    FQ(TxContextFieldTag.CallDataLength),
+                    FQ(0),
+                    FQ(len(self.call_data)),
+                ),
+                TxTableRow(
+                    FQ(self.id),
+                    FQ(TxContextFieldTag.CallDataGasCost),
+                    FQ(0),
+                    FQ(self.call_data_gas_cost()),
+                ),
             ],
             map(
-                lambda item: (self.id, TxContextFieldTag.CallData, item[0], item[1]),
+                lambda item: TxTableRow(
+                    FQ(self.id), FQ(TxContextFieldTag.CallData), FQ(item[0]), FQ(item[1])
+                ),
                 enumerate(self.call_data),
             ),
         )
@@ -163,13 +212,13 @@ class Bytecode:
 
         return method
 
-    def push(self, value: Any, n_bytes: int = 32) -> Bytecode:
+    def push(self, value: Union[int, str, bytes, bytearray, RLC], n_bytes: int = 32) -> Bytecode:
         if isinstance(value, int):
             value = value.to_bytes(n_bytes, "big")
         elif isinstance(value, str):
             value = bytes.fromhex(value.lower().removeprefix("0x"))
         elif isinstance(value, RLC):
-            value = value.be_bytes()
+            value = bytes(reversed(value.le_bytes))
         elif isinstance(value, bytes) or isinstance(value, bytearray):
             ...
         else:
@@ -179,21 +228,21 @@ class Bytecode:
 
         opcode = Opcode.PUSH1 + n_bytes - 1
         self.code.append(opcode)
-        self.code.extend(value.rjust(n_bytes, bytes(1)))
+        self.code.extend(value.rjust(n_bytes, b"\x00"))
 
         return self
 
-    def hash(self) -> int:
-        return int.from_bytes(keccak256(self.code), "big")
+    def hash(self) -> U256:
+        return U256(int.from_bytes(keccak256(self.code), "big"))
 
-    def table_assignments(self, randomness: int) -> Iterator[Array4]:
+    def table_assignments(self, randomness: FQ) -> Iterator[BytecodeTableRow]:
         class BytecodeIterator:
             idx: int
             push_data_left: int
-            hash: RLC
+            hash: FQ
             code: bytes
 
-            def __init__(self, hash: RLC, code: bytes):
+            def __init__(self, hash: FQ, code: bytes):
                 self.idx = 0
                 self.push_data_left = 0
                 self.hash = hash
@@ -214,9 +263,9 @@ class Bytecode:
 
                 self.idx += 1
 
-                return (self.hash, idx, byte, is_code)
+                return BytecodeTableRow(self.hash, FQ(idx), FQ(byte), FQ(is_code))
 
-        return BytecodeIterator(RLC(self.hash(), randomness), self.code)
+        return BytecodeIterator(RLC(self.hash(), randomness).expr(), self.code)
 
 
 Storage = NewType("Storage", Dict[U256, U256])
@@ -231,20 +280,269 @@ class Account:
 
     def __init__(
         self,
-        address: U160 = 0,
-        nonce: U256 = 0,
-        balance: U256 = 0,
-        code: Optional[Bytecode] = None,
-        storage: Optional[Storage] = None,
+        address: U160 = U160(0),
+        nonce: U256 = U256(0),
+        balance: U256 = U256(0),
+        code: Bytecode = None,
+        storage: Storage = None,
     ) -> None:
         self.address = address
         self.nonce = nonce
         self.balance = balance
         self.code = Bytecode() if code is None else code
-        self.storage = dict() if storage is None else storage
+        self.storage = Storage(dict()) if storage is None else storage
 
     def code_hash(self) -> U256:
         return self.code.hash()
 
     def storage_trie_hash(self) -> U256:
         raise NotImplementedError("Trie has not been implemented")
+
+
+class RWDictionary:
+    rw_counter: int
+    rws: List[RWTableRow]
+
+    def __init__(self, rw_counter: int) -> None:
+        self.rw_counter = rw_counter
+        self.rws = list()
+
+    def stack_read(self, call_id: IntOrFQ, stack_pointer: IntOrFQ, value: RLC) -> RWDictionary:
+        return self._append(
+            RW.Read, RWTableTag.Stack, key1=FQ(call_id), key2=FQ(stack_pointer), value=value
+        )
+
+    def stack_write(self, call_id: IntOrFQ, stack_pointer: IntOrFQ, value: RLC) -> RWDictionary:
+        return self._append(
+            RW.Write, RWTableTag.Stack, key1=FQ(call_id), key2=FQ(stack_pointer), value=value
+        )
+
+    def memory_read(self, call_id: IntOrFQ, memory_address: IntOrFQ, byte: IntOrFQ) -> RWDictionary:
+        return self._append(
+            RW.Read, RWTableTag.Memory, key1=FQ(call_id), key2=FQ(memory_address), value=FQ(byte)
+        )
+
+    def memory_write(
+        self, call_id: IntOrFQ, memory_address: IntOrFQ, byte: IntOrFQ
+    ) -> RWDictionary:
+        return self._append(
+            RW.Write, RWTableTag.Memory, key1=FQ(call_id), key2=FQ(memory_address), value=FQ(byte)
+        )
+
+    def call_context_read(
+        self, call_id: IntOrFQ, field_tag: CallContextFieldTag, value: Union[int, FQ, RLC]
+    ) -> RWDictionary:
+        if isinstance(value, int):
+            value = FQ(value)
+        return self._append(
+            RW.Read, RWTableTag.CallContext, key1=FQ(call_id), key2=FQ(field_tag), value=value
+        )
+
+    def tx_refund_read(self, tx_id: IntOrFQ, refund: IntOrFQ) -> RWDictionary:
+        return self._append(
+            RW.Read, RWTableTag.TxRefund, key1=FQ(tx_id), value=FQ(refund), value_prev=FQ(refund)
+        )
+
+    def tx_refund_write(
+        self,
+        tx_id: IntOrFQ,
+        refund: IntOrFQ,
+        refund_prev: IntOrFQ,
+        rw_counter_of_reversion: int = None,
+    ) -> RWDictionary:
+        return self._state_write(
+            RWTableTag.TxRefund,
+            key1=FQ(tx_id),
+            value=FQ(refund),
+            value_prev=FQ(refund_prev),
+            rw_counter_of_reversion=rw_counter_of_reversion,
+        )
+
+    def tx_access_list_account_write(
+        self,
+        tx_id: IntOrFQ,
+        account_address: IntOrFQ,
+        value: bool,
+        value_prev: bool,
+        rw_counter_of_reversion: int = None,
+    ) -> RWDictionary:
+        return self._state_write(
+            RWTableTag.TxAccessListAccount,
+            key1=FQ(tx_id),
+            key2=FQ(account_address),
+            value=FQ(value),
+            value_prev=FQ(value_prev),
+            rw_counter_of_reversion=rw_counter_of_reversion,
+        )
+
+    def tx_access_list_account_storage_write(
+        self,
+        tx_id: IntOrFQ,
+        account_address: IntOrFQ,
+        storage_key: RLC,
+        value: bool,
+        value_prev: bool,
+        rw_counter_of_reversion: int = None,
+    ) -> RWDictionary:
+        return self._state_write(
+            RWTableTag.TxAccessListAccountStorage,
+            key1=FQ(tx_id),
+            key2=FQ(account_address),
+            key3=storage_key,
+            value=FQ(value),
+            value_prev=FQ(value_prev),
+            rw_counter_of_reversion=rw_counter_of_reversion,
+        )
+
+    def account_read(
+        self, account_address: IntOrFQ, field_tag: AccountFieldTag, value: Union[int, FQ, RLC]
+    ) -> RWDictionary:
+        if isinstance(value, int):
+            value = FQ(value)
+        return self._append(
+            RW.Read,
+            RWTableTag.Account,
+            key1=FQ(account_address),
+            key2=FQ(field_tag),
+            value=value,
+            value_prev=value,
+        )
+
+    def account_write(
+        self,
+        account_address: IntOrFQ,
+        field_tag: AccountFieldTag,
+        value: Union[int, FQ, RLC],
+        value_prev: Union[int, FQ, RLC],
+        rw_counter_of_reversion: int = None,
+    ) -> RWDictionary:
+        if isinstance(value, int):
+            value = FQ(value)
+        if isinstance(value_prev, int):
+            value_prev = FQ(value_prev)
+        return self._state_write(
+            RWTableTag.Account,
+            key1=FQ(account_address),
+            key2=FQ(field_tag),
+            value=value,
+            value_prev=value_prev,
+            rw_counter_of_reversion=rw_counter_of_reversion,
+        )
+
+    def account_storage_read(
+        self,
+        account_address: IntOrFQ,
+        storage_key: RLC,
+        value: RLC,
+        tx_id: IntOrFQ,
+        value_committed: RLC,
+    ) -> RWDictionary:
+        if isinstance(tx_id, int):
+            tx_id = FQ(tx_id)
+        return self._append(
+            RW.Read,
+            RWTableTag.AccountStorage,
+            key1=FQ(account_address),
+            key2=storage_key,
+            value=value,
+            value_prev=value,
+            aux0=tx_id,
+            aux1=value_committed,
+        )
+
+    def account_storage_write(
+        self,
+        account_address: IntOrFQ,
+        storage_key: RLC,
+        value: RLC,
+        value_prev: RLC,
+        tx_id: IntOrFQ,
+        value_committed: RLC,
+        rw_counter_of_reversion: int = None,
+    ) -> RWDictionary:
+        if isinstance(tx_id, int):
+            tx_id = FQ(tx_id)
+        return self._state_write(
+            RWTableTag.AccountStorage,
+            key1=FQ(account_address),
+            key2=storage_key,
+            value=value,
+            value_prev=value_prev,
+            aux0=tx_id,
+            aux1=value_committed,
+            rw_counter_of_reversion=rw_counter_of_reversion,
+        )
+
+    def _state_write(
+        self,
+        tag: RWTableTag,
+        key1: Expression = FQ(0),
+        key2: Expression = FQ(0),
+        key3: Expression = FQ(0),
+        value: Expression = FQ(0),
+        value_prev: Expression = FQ(0),
+        aux0: Expression = FQ(0),
+        aux1: Expression = FQ(0),
+        rw_counter_of_reversion: int = None,
+    ) -> RWDictionary:
+        self._append(
+            RW.Write,
+            tag=tag,
+            key1=key1,
+            key2=key2,
+            key3=key3,
+            value=value,
+            value_prev=value_prev,
+            aux0=aux0,
+            aux1=aux1,
+        )
+
+        if rw_counter_of_reversion is None:
+            return self
+        else:
+            return self._append(
+                RW.Write,
+                tag=tag,
+                key1=key1,
+                key2=key2,
+                key3=key3,
+                value=value_prev,
+                value_prev=value,
+                aux0=aux0,
+                aux1=aux1,
+                rw_counter=rw_counter_of_reversion,
+            )
+
+    def _append(
+        self,
+        rw: RW,
+        tag: RWTableTag,
+        key1: Expression = FQ(0),
+        key2: Expression = FQ(0),
+        key3: Expression = FQ(0),
+        value: Expression = FQ(0),
+        value_prev: Expression = FQ(0),
+        aux0: Expression = FQ(0),
+        aux1: Expression = FQ(0),
+        rw_counter: int = None,
+    ) -> RWDictionary:
+        if rw_counter is None:
+            rw_counter = self.rw_counter
+            self.rw_counter += 1
+
+        self.rws.append(
+            RWTableRow(
+                FQ(rw_counter),
+                FQ(rw),
+                FQ(tag),
+                key1,
+                key2,
+                key3,
+                value,
+                value_prev,
+                aux0,
+                aux1,
+            )
+        )
+
+        return self

--- a/src/zkevm_specs/evm/util/memory_gadget.py
+++ b/src/zkevm_specs/evm/util/memory_gadget.py
@@ -1,5 +1,5 @@
-from ...util import N_BYTES_MEMORY_ADDRESS, FQ
-from ..instruction import Instruction, Transition
+from ...util import N_BYTES_MEMORY_ADDRESS, FQ, Expression
+from ..instruction import Instruction
 
 
 class BufferReaderGadget:
@@ -24,7 +24,7 @@ class BufferReaderGadget:
                 diff, inst.select(self.bound_dist_is_zero[i - 1], FQ.zero(), FQ.one())
             )
 
-    def constrain_byte(self, idx: int, byte: FQ):
+    def constrain_byte(self, idx: int, byte: Expression):
         # bytes[idx] == 0 when selectors[idx] == 0
         self.instruction.constrain_zero(byte * (1 - self.selectors[idx]))
         # bytes[idx] == 0 when bound_dist[idx] == 0
@@ -33,8 +33,8 @@ class BufferReaderGadget:
     def num_bytes(self) -> FQ:
         return FQ(sum(self.selectors))
 
-    def has_data(self, idx: int) -> bool:
+    def has_data(self, idx: int) -> FQ:
         return self.selectors[idx]
 
-    def read_flag(self, idx: int) -> bool:
-        return self.selectors[idx] and not self.bound_dist_is_zero[idx]
+    def read_flag(self, idx: int) -> FQ:
+        return self.selectors[idx] * (1 - self.bound_dist_is_zero[idx])

--- a/src/zkevm_specs/opcode/comparator.py
+++ b/src/zkevm_specs/opcode/comparator.py
@@ -34,7 +34,7 @@ def compare(
     assert len(result) == 16
 
     # Before we do any comparison, the previous result is "equal"
-    result = result[:] + [0]
+    result = list(result[:]) + [Sign(0)]
 
     for i in reversed(range(0, 32, 2)):
         a16 = a8s[i] + 256 * a8s[i + 1]

--- a/src/zkevm_specs/opcode/lt_gt.py
+++ b/src/zkevm_specs/opcode/lt_gt.py
@@ -1,6 +1,6 @@
 from typing import Sequence
 
-from ..encoding import is_circuit_code, U8, U256, u256_to_u8s
+from ..encoding import is_circuit_code, U8
 
 
 def lt_circuit(
@@ -34,7 +34,7 @@ def lt_circuit(
     # lower 16 bytes
     # a[15:0] + c[15:0] == carry * 256^16 + b[15:0]
     lhs = 0
-    rhs = carry
+    rhs = int(carry)
     for i in reversed(range(16)):
         lhs = lhs * 256 + a8s[i] + c8s[i]
         rhs = rhs * 256 + b8s[i]

--- a/src/zkevm_specs/opcode/mload_mstore.py
+++ b/src/zkevm_specs/opcode/mload_mstore.py
@@ -15,14 +15,15 @@ NUM_ADDRESS_BYTES_USED = 5
 def address_low(
     address: Sequence[U8],
 ) -> U64:
-    return sum(x * (2 ** (8 * i)) for i, x in enumerate(address[:NUM_ADDRESS_BYTES_USED]))
+    _sum = sum(x * (2 ** (8 * i)) for i, x in enumerate(address[:NUM_ADDRESS_BYTES_USED]))
+    return U64(_sum)
 
 
 @is_circuit_code
 def address_high(
     address: Sequence[U8],
 ) -> U256:
-    return sum(address[NUM_ADDRESS_BYTES_USED:])
+    return U256(sum(address[NUM_ADDRESS_BYTES_USED:]))
 
 
 @is_circuit_code
@@ -38,7 +39,7 @@ def select(
     when_true: U256,
     when_false: U256,
 ) -> U256:
-    return selector * when_true + (1 - selector) * when_false
+    return U256(selector * when_true + (1 - selector) * when_false)
 
 
 @is_circuit_code
@@ -46,8 +47,8 @@ def div(
     value: U256,
     divisor: U64,
 ) -> Tuple[U256, U256]:
-    quotient = value // divisor
-    remainder = value % divisor
+    quotient = U256(value // divisor)
+    remainder = U256(value % divisor)
     return (quotient, remainder)
 
 
@@ -56,7 +57,7 @@ def lt(
     lhs: U256,
     rhs: U256,
 ) -> U256:
-    return lhs < rhs
+    return U256(lhs < rhs)
 
 
 @is_circuit_code
@@ -71,7 +72,7 @@ def max(
 def memory_size(
     address: U64,
 ) -> U64:
-    return (address + 31) // 32
+    return U64((address + 31) // 32)
 
 
 @is_circuit_code

--- a/src/zkevm_specs/state.py
+++ b/src/zkevm_specs/state.py
@@ -1,10 +1,10 @@
 from typing import NamedTuple, Tuple, List, Sequence
-from enum import IntEnum, auto
+from enum import IntEnum
 from math import log, ceil
+
 from .util import FQ, RLC, U160, U256
 from .encoding import U8, is_circuit_code
-from .evm import RW, RWTableTag
-from .evm import AccountFieldTag, CallContextFieldTag
+from .evm import RW, AccountFieldTag, CallContextFieldTag
 
 MAX_KEY_DIFF = 2**32 - 1
 MAX_MEMORY_ADDRESS = 2**32 - 1
@@ -523,7 +523,7 @@ def op2row(op: Operation, randomness: FQ) -> Row:
     key2_bytes = op.key2.to_bytes(20, "little")
     key2_limbs = tuple([FQ(key2_bytes[i] + 2**8 * key2_bytes[i + 1]) for i in range(0, 20, 2)])
     key3 = FQ(op.key3)
-    key4_rlc = RLC(op.key4, randomness.n)
+    key4_rlc = RLC(op.key4, randomness)
     key4 = key4_rlc.value
     key4_bytes = tuple([FQ(x) for x in key4_rlc.le_bytes])
     value = FQ(op.value)
@@ -532,7 +532,8 @@ def op2row(op: Operation, randomness: FQ) -> Row:
 
     # fmt: off
     return Row(rw_counter, is_write,
-            (key0, key1, key2, key3, key4), key2_limbs, key4_bytes, # keys
+            # keys
+            (key0, key1, key2, key3, key4), key2_limbs, key4_bytes, # type: ignore
             value, (aux0, aux1)) # values
     # fmt: on
 

--- a/src/zkevm_specs/util/__init__.py
+++ b/src/zkevm_specs/util/__init__.py
@@ -12,16 +12,16 @@ def rand_range(stop: Union[int, float] = 2**256) -> int:
     return randrange(0, int(stop))
 
 
-def rand_fp() -> FQ:
+def rand_fq() -> FQ:
     return FQ(rand_range(FQ.field_modulus))
 
 
 def rand_address() -> U160:
-    return rand_range(2**160)
+    return U160(rand_range(2**160))
 
 
 def rand_word() -> U256:
-    return rand_range(2**256)
+    return U256(rand_range(2**256))
 
 
 def rand_bytes(n_bytes: int = 32) -> bytes:

--- a/src/zkevm_specs/util/hash.py
+++ b/src/zkevm_specs/util/hash.py
@@ -5,11 +5,11 @@ from .typing import U256
 
 
 def keccak256(data: Union[str, bytes, bytearray]) -> bytes:
-    if type(data) == str:
+    if isinstance(data, str):
         data = bytes.fromhex(data)
     return keccak.new(digest_bits=256).update(data).digest()
 
 
-EMPTY_HASH: U256 = int.from_bytes(keccak256(""), "big")
+EMPTY_HASH: U256 = U256(int.from_bytes(keccak256(""), "big"))
 EMPTY_CODE_HASH: U256 = EMPTY_HASH
-EMPTY_TRIE_HASH: U256 = int.from_bytes(keccak256("80"), "big")
+EMPTY_TRIE_HASH: U256 = U256(int.from_bytes(keccak256("80"), "big"))

--- a/src/zkevm_specs/util/typing.py
+++ b/src/zkevm_specs/util/typing.py
@@ -1,48 +1,5 @@
-from typing import NewType, Tuple
+from typing import NewType
 
 U64 = NewType("U64", int)
 U160 = NewType("U160", int)
 U256 = NewType("U256", int)
-
-
-Array3 = NewType("Array3", Tuple[int, int, int])
-Array4 = NewType("Array4", Tuple[int, int, int, int])
-Array8 = NewType("Array8", Tuple[int, int, int, int, int, int, int, int])
-Array10 = NewType("Array10", Tuple[int, int, int, int, int, int, int, int, int, int])
-Array32 = NewType(
-    "Array32",
-    Tuple[
-        int,
-        int,
-        int,
-        int,
-        int,
-        int,
-        int,
-        int,
-        int,
-        int,
-        int,
-        int,
-        int,
-        int,
-        int,
-        int,
-        int,
-        int,
-        int,
-        int,
-        int,
-        int,
-        int,
-        int,
-        int,
-        int,
-        int,
-        int,
-        int,
-        int,
-        int,
-        int,
-    ],
-)

--- a/tests/evm/test_add.py
+++ b/tests/evm/test_add.py
@@ -7,12 +7,11 @@ from zkevm_specs.evm import (
     Opcode,
     verify_steps,
     Tables,
-    RWTableTag,
-    RW,
     Block,
     Bytecode,
+    RWDictionary,
 )
-from zkevm_specs.util import rand_fp, rand_word, RLC
+from zkevm_specs.util import rand_fq, rand_word, RLC
 
 
 TESTING_DATA = (
@@ -25,7 +24,7 @@ TESTING_DATA = (
 
 @pytest.mark.parametrize("opcode, a, b, c", TESTING_DATA)
 def test_add(opcode: Opcode, a: int, b: int, c: Optional[int]):
-    randomness = rand_fp()
+    randomness = rand_fq()
 
     c = (
         RLC(c, randomness)
@@ -43,11 +42,11 @@ def test_add(opcode: Opcode, a: int, b: int, c: Optional[int]):
         tx_table=set(),
         bytecode_table=set(bytecode.table_assignments(randomness)),
         rw_table=set(
-            [
-                (9, RW.Read, RWTableTag.Stack, 1, 1022, 0, a, 0, 0, 0),
-                (10, RW.Read, RWTableTag.Stack, 1, 1023, 0, b, 0, 0, 0),
-                (11, RW.Write, RWTableTag.Stack, 1, 1023, 0, c, 0, 0, 0),
-            ]
+            RWDictionary(9)
+            .stack_read(1, 1022, a)
+            .stack_read(1, 1023, b)
+            .stack_write(1, 1023, c)
+            .rws
         ),
     )
 

--- a/tests/evm/test_calldatasize.py
+++ b/tests/evm/test_calldatasize.py
@@ -5,13 +5,11 @@ from zkevm_specs.evm import (
     StepState,
     verify_steps,
     Tables,
-    RWTableTag,
-    RW,
     CallContextFieldTag,
     Bytecode,
+    RWDictionary,
 )
-from zkevm_specs.util import rand_fp, RLC, U64
-from zkevm_specs.util.param import N_BYTES_U64
+from zkevm_specs.util import rand_fq, RLC, U64
 
 
 TESTING_DATA = (
@@ -23,7 +21,7 @@ TESTING_DATA = (
 
 @pytest.mark.parametrize("calldatasize", TESTING_DATA)
 def test_calldatasize(calldatasize: U64):
-    randomness = rand_fp()
+    randomness = rand_fq()
 
     bytecode = Bytecode().calldatasize()
     bytecode_hash = RLC(bytecode.hash(), randomness)
@@ -33,12 +31,10 @@ def test_calldatasize(calldatasize: U64):
         tx_table=set(),
         bytecode_table=set(bytecode.table_assignments(randomness)),
         rw_table=set(
-            [
-                # fmt: off
-                (9, RW.Read, RWTableTag.CallContext, 1, CallContextFieldTag.CallDataLength, 0, calldatasize, 0, 0, 0),
-                (10, RW.Write, RWTableTag.Stack, 1, 1023, 0, RLC(calldatasize, randomness, N_BYTES_U64), 0, 0, 0),
-                # fmt: on
-            ]
+            RWDictionary(9)
+            .call_context_read(1, CallContextFieldTag.CallDataLength, calldatasize)
+            .stack_write(1, 1023, RLC(calldatasize, randomness))
+            .rws
         ),
     )
 

--- a/tests/evm/test_caller.py
+++ b/tests/evm/test_caller.py
@@ -5,13 +5,11 @@ from zkevm_specs.evm import (
     StepState,
     verify_steps,
     Tables,
-    RWTableTag,
-    RW,
     CallContextFieldTag,
     Bytecode,
+    RWDictionary,
 )
-from zkevm_specs.util import rand_address, rand_fp, RLC, U160
-from zkevm_specs.util.param import N_BYTES_ACCOUNT_ADDRESS
+from zkevm_specs.util import rand_address, rand_fq, RLC, U160
 
 
 TESTING_DATA = (
@@ -25,7 +23,7 @@ TESTING_DATA = (
 
 @pytest.mark.parametrize("caller", TESTING_DATA)
 def test_caller(caller: U160):
-    randomness = rand_fp()
+    randomness = rand_fq()
 
     bytecode = Bytecode().caller()
     bytecode_hash = RLC(bytecode.hash(), randomness)
@@ -35,12 +33,10 @@ def test_caller(caller: U160):
         tx_table=set(),
         bytecode_table=set(bytecode.table_assignments(randomness)),
         rw_table=set(
-            [
-                # fmt: off
-                (9, RW.Read, RWTableTag.CallContext, 1, CallContextFieldTag.CallerAddress, 0, caller, 0, 0, 0),
-                (10, RW.Write, RWTableTag.Stack, 1, 1023, 0, RLC(caller, randomness, N_BYTES_ACCOUNT_ADDRESS), 0, 0, 0),
-                # fmt: on
-            ]
+            RWDictionary(9)
+            .call_context_read(1, CallContextFieldTag.CallerAddress, caller)
+            .stack_write(1, 1023, RLC(caller, randomness))
+            .rws
         ),
     )
 

--- a/tests/evm/test_coinbase.py
+++ b/tests/evm/test_coinbase.py
@@ -5,12 +5,11 @@ from zkevm_specs.evm import (
     StepState,
     verify_steps,
     Tables,
-    RWTableTag,
-    RW,
     Block,
     Bytecode,
+    RWDictionary,
 )
-from zkevm_specs.util import rand_address, rand_fp, RLC, U160
+from zkevm_specs.util import rand_address, rand_fq, RLC, U160
 
 
 TESTING_DATA = (0x030201, rand_address())
@@ -18,7 +17,7 @@ TESTING_DATA = (0x030201, rand_address())
 
 @pytest.mark.parametrize("coinbase", TESTING_DATA)
 def test_coinbase(coinbase: U160):
-    randomness = rand_fp()
+    randomness = rand_fq()
 
     block = Block(coinbase=coinbase)
 
@@ -29,11 +28,7 @@ def test_coinbase(coinbase: U160):
         block_table=set(block.table_assignments(randomness)),
         tx_table=set(),
         bytecode_table=set(bytecode.table_assignments(randomness)),
-        rw_table=set(
-            [
-                (9, RW.Write, RWTableTag.Stack, 1, 1023, 0, RLC(coinbase, randomness, 20), 0, 0, 0),
-            ]
-        ),
+        rw_table=set(RWDictionary(9).stack_write(1, 1023, RLC(coinbase, randomness)).rws),
     )
 
     verify_steps(

--- a/tests/evm/test_end_block.py
+++ b/tests/evm/test_end_block.py
@@ -7,19 +7,20 @@ from zkevm_specs.evm import (
     verify_steps,
     Tables,
     RWTableTag,
+    RWTableRow,
     RW,
     CallContextFieldTag,
     Block,
     Transaction,
 )
-from zkevm_specs.util import rand_fp
+from zkevm_specs.util import rand_fq, FQ
 
 TESTING_DATA = (False, True)
 
 
 @pytest.mark.parametrize("is_last_step", TESTING_DATA)
 def test_end_block(is_last_step: bool):
-    randomness = rand_fp()
+    randomness = rand_fq()
 
     tx = Transaction()
 
@@ -30,8 +31,8 @@ def test_end_block(is_last_step: bool):
         rw_table=set(
             chain(
                 # dummy read/write for counting
-                [(i, *7 * [0]) for i in range(22)],
-                [(22, RW.Read, RWTableTag.CallContext, 1, CallContextFieldTag.TxId, 0, tx.id, 0, 0, 0)]  # fmt: skip
+                [RWTableRow(FQ(i), *9 * [FQ(0)]) for i in range(22)],
+                [RWTableRow(FQ(22), FQ(RW.Read), FQ(RWTableTag.CallContext), FQ(1), FQ(CallContextFieldTag.TxId), value=FQ(tx.id))]  # fmt: skip
                 if is_last_step else [],
             )
         ),

--- a/tests/evm/test_jump.py
+++ b/tests/evm/test_jump.py
@@ -6,12 +6,11 @@ from zkevm_specs.evm import (
     Opcode,
     verify_steps,
     Tables,
-    RWTableTag,
-    RW,
     Block,
     Bytecode,
+    RWDictionary,
 )
-from zkevm_specs.util import rand_fp, RLC
+from zkevm_specs.util import rand_fq, RLC
 
 
 TESTING_DATA = ((Opcode.JUMP, bytes([7])),)
@@ -19,7 +18,7 @@ TESTING_DATA = ((Opcode.JUMP, bytes([7])),)
 
 @pytest.mark.parametrize("opcode, dest_bytes", TESTING_DATA)
 def test_jump(opcode: Opcode, dest_bytes: bytes):
-    randomness = rand_fp()
+    randomness = rand_fq()
     dest = RLC(bytes(reversed(dest_bytes)), randomness)
 
     block = Block()
@@ -32,11 +31,7 @@ def test_jump(opcode: Opcode, dest_bytes: bytes):
         block_table=set(block.table_assignments(randomness)),
         tx_table=set(),
         bytecode_table=set(bytecode.table_assignments(randomness)),
-        rw_table=set(
-            [
-                (9, RW.Read, RWTableTag.Stack, 1, 1021, 0, dest, 0, 0, 0),
-            ]
-        ),
+        rw_table=set(RWDictionary(9).stack_read(1, 1021, dest).rws),
     )
 
     verify_steps(

--- a/tests/evm/test_jumpi.py
+++ b/tests/evm/test_jumpi.py
@@ -6,12 +6,11 @@ from zkevm_specs.evm import (
     Opcode,
     verify_steps,
     Tables,
-    RWTableTag,
-    RW,
     Block,
     Bytecode,
+    RWDictionary,
 )
-from zkevm_specs.util import rand_fp, RLC
+from zkevm_specs.util import rand_fq, RLC
 
 
 TESTING_DATA = ((Opcode.JUMPI, bytes([40]), bytes([7])),)
@@ -19,7 +18,7 @@ TESTING_DATA = ((Opcode.JUMPI, bytes([40]), bytes([7])),)
 
 @pytest.mark.parametrize("opcode, cond_bytes, dest_bytes", TESTING_DATA)
 def test_jumpi_cond_nonzero(opcode: Opcode, cond_bytes: bytes, dest_bytes: bytes):
-    randomness = rand_fp()
+    randomness = rand_fq()
     cond = RLC(bytes(reversed(cond_bytes)), randomness)
     dest = RLC(bytes(reversed(dest_bytes)), randomness)
 
@@ -33,12 +32,7 @@ def test_jumpi_cond_nonzero(opcode: Opcode, cond_bytes: bytes, dest_bytes: bytes
         block_table=set(block.table_assignments(randomness)),
         tx_table=set(),
         bytecode_table=set(bytecode.table_assignments(randomness)),
-        rw_table=set(
-            [
-                (9, RW.Read, RWTableTag.Stack, 1, 1021, 0, dest, 0, 0, 0),
-                (10, RW.Read, RWTableTag.Stack, 1, 1022, 0, cond, 0, 0, 0),
-            ],
-        ),
+        rw_table=set(RWDictionary(9).stack_read(1, 1021, dest).stack_read(1, 1022, cond).rws),
     )
 
     verify_steps(
@@ -76,7 +70,7 @@ TESTING_DATA_ZERO_COND = ((Opcode.JUMPI, bytes([0]), bytes([8])),)
 
 @pytest.mark.parametrize("opcode, cond_bytes, dest_bytes", TESTING_DATA_ZERO_COND)
 def test_jumpi_cond_zero(opcode: Opcode, cond_bytes: bytes, dest_bytes: bytes):
-    randomness = rand_fp()
+    randomness = rand_fq()
     cond = RLC(bytes(reversed(cond_bytes)), randomness)
     dest = RLC(bytes(reversed(dest_bytes)), randomness)
 
@@ -90,12 +84,7 @@ def test_jumpi_cond_zero(opcode: Opcode, cond_bytes: bytes, dest_bytes: bytes):
         block_table=set(block.table_assignments(randomness)),
         tx_table=set(),
         bytecode_table=set(bytecode.table_assignments(randomness)),
-        rw_table=set(
-            [
-                (9, RW.Read, RWTableTag.Stack, 1, 1021, 0, dest, 0, 0, 0),
-                (10, RW.Read, RWTableTag.Stack, 1, 1022, 0, cond, 0, 0, 0),
-            ],
-        ),
+        rw_table=set(RWDictionary(9).stack_read(1, 1021, dest).stack_read(1, 1022, cond).rws),
     )
 
     verify_steps(

--- a/tests/evm/test_number.py
+++ b/tests/evm/test_number.py
@@ -5,12 +5,11 @@ from zkevm_specs.evm import (
     StepState,
     verify_steps,
     Tables,
-    RWTableTag,
-    RW,
     Block,
     Bytecode,
+    RWDictionary,
 )
-from zkevm_specs.util import rand_address, rand_fp, RLC, U256, rand_word
+from zkevm_specs.util import rand_fq, RLC, U256, rand_word
 
 
 TESTING_DATA = (0, 1, 2**256 - 1, rand_word())
@@ -18,7 +17,7 @@ TESTING_DATA = (0, 1, 2**256 - 1, rand_word())
 
 @pytest.mark.parametrize("number", TESTING_DATA)
 def test_number(number: U256):
-    randomness = rand_fp()
+    randomness = rand_fq()
 
     block = Block(number=number)
 
@@ -29,11 +28,7 @@ def test_number(number: U256):
         block_table=set(block.table_assignments(randomness)),
         tx_table=set(),
         bytecode_table=set(bytecode.table_assignments(randomness)),
-        rw_table=set(
-            [
-                (9, RW.Write, RWTableTag.Stack, 1, 1023, 0, RLC(number, randomness), 0, 0, 0),
-            ]
-        ),
+        rw_table=set(RWDictionary(9).stack_write(1, 1023, RLC(number, randomness)).rws),
     )
 
     verify_steps(

--- a/tests/evm/test_selfbalance.py
+++ b/tests/evm/test_selfbalance.py
@@ -5,39 +5,34 @@ from zkevm_specs.evm import (
     StepState,
     verify_steps,
     Tables,
-    RWTableTag,
-    RW,
     Block,
     Bytecode,
     CallContextFieldTag,
     AccountFieldTag,
+    RWDictionary,
 )
-from zkevm_specs.util import rand_address, rand_word, rand_fp, RLC, U256, U160
+from zkevm_specs.util import rand_address, rand_word, rand_fq, RLC, U256, U160
 
 TESTING_DATA = [(0, 0), (0, 10), (rand_address(), rand_word())]
 
 
 @pytest.mark.parametrize("callee_address, balance", TESTING_DATA)
 def test_selfbalance(callee_address: U160, balance: U256):
-    randomness = rand_fp()
+    randomness = rand_fq()
 
     bytecode = Bytecode().selfbalance()
     bytecode_hash = RLC(bytecode.hash(), randomness)
-
-    rlc_balance = RLC(balance, randomness)
 
     tables = Tables(
         block_table=Block(),
         tx_table=set(),
         bytecode_table=set(bytecode.table_assignments(randomness)),
         rw_table=set(
-            [
-                # fmt: off
-                (9, RW.Read, RWTableTag.CallContext, 1, CallContextFieldTag.CalleeAddress, 0, callee_address, 0, 0, 0),
-                (10, RW.Read, RWTableTag.Account, callee_address, AccountFieldTag.Balance, 0, rlc_balance, rlc_balance, 0, 0, 0),
-                (11, RW.Write, RWTableTag.Stack, 1, 1023, 0, rlc_balance, 0, 0, 0),
-                # fmt: on
-            ]
+            RWDictionary(9)
+            .call_context_read(1, CallContextFieldTag.CalleeAddress, callee_address)
+            .account_read(callee_address, AccountFieldTag.Balance, RLC(balance, randomness))
+            .stack_write(1, 1023, RLC(balance, randomness))
+            .rws
         ),
     )
 

--- a/tests/evm/test_slt_sgt.py
+++ b/tests/evm/test_slt_sgt.py
@@ -6,12 +6,11 @@ from zkevm_specs.evm import (
     Opcode,
     verify_steps,
     Tables,
-    RWTableTag,
-    RW,
     Block,
     Bytecode,
+    RWDictionary,
 )
-from zkevm_specs.util import rand_fp, rand_word, RLC
+from zkevm_specs.util import rand_fq, rand_word, RLC
 
 RAND_1 = rand_word()
 
@@ -186,7 +185,7 @@ TESTING_DATA = (
 
 @pytest.mark.parametrize("opcode, a, b, res", TESTING_DATA)
 def test_slt_sgt(opcode: Opcode, a: int, b: int, res: int):
-    randomness = rand_fp()
+    randomness = rand_fq()
 
     a = RLC(a, randomness)
     b = RLC(b, randomness)
@@ -200,11 +199,11 @@ def test_slt_sgt(opcode: Opcode, a: int, b: int, res: int):
         tx_table=set(),
         bytecode_table=set(bytecode.table_assignments(randomness)),
         rw_table=set(
-            [
-                (9, RW.Read, RWTableTag.Stack, 1, 1022, 0, a, 0, 0, 0),
-                (10, RW.Read, RWTableTag.Stack, 1, 1023, 0, b, 0, 0, 0),
-                (11, RW.Write, RWTableTag.Stack, 1, 1023, 0, res, 0, 0, 0),
-            ]
+            RWDictionary(9)
+            .stack_read(1, 1022, a)
+            .stack_read(1, 1023, b)
+            .stack_write(1, 1023, res)
+            .rws
         ),
     )
 

--- a/tests/evm/test_timestamp.py
+++ b/tests/evm/test_timestamp.py
@@ -5,19 +5,18 @@ from zkevm_specs.evm import (
     StepState,
     verify_steps,
     Tables,
-    RWTableTag,
-    RW,
     Block,
     Bytecode,
+    RWDictionary,
 )
-from zkevm_specs.util import rand_range, rand_fp, RLC, U64
+from zkevm_specs.util import rand_range, rand_fq, RLC, U64
 
 TESTING_DATA = (0, 1, 2**64 - 1, rand_range(2**64))
 
 
 @pytest.mark.parametrize("timestamp", TESTING_DATA)
 def test_timestamp(timestamp: U64):
-    randomness = rand_fp()
+    randomness = rand_fq()
 
     block = Block(timestamp=timestamp)
 
@@ -28,11 +27,7 @@ def test_timestamp(timestamp: U64):
         block_table=set(block.table_assignments(randomness)),
         tx_table=set(),
         bytecode_table=set(bytecode.table_assignments(randomness)),
-        rw_table=set(
-            [
-                (9, RW.Write, RWTableTag.Stack, 1, 1023, 0, RLC(timestamp, randomness, 8), 0, 0, 0),
-            ]
-        ),
+        rw_table=set(RWDictionary(9).stack_write(1, 1023, RLC(timestamp, randomness)).rws),
     )
 
     verify_steps(

--- a/tests/test_bitwise.py
+++ b/tests/test_bitwise.py
@@ -1,7 +1,7 @@
 import random
 import pytest
 
-from zkevm_specs.encoding import u256_to_u8s, u8s_to_u256
+from zkevm_specs.encoding import u256_to_u8s
 from zkevm_specs.opcode import check_and, check_or, check_xor
 
 
@@ -28,8 +28,7 @@ def test_check_or():
 
 
 def test_check_xor():
-    for i in range(5):
-        print(i)
+    for _ in range(5):
         a = random.randint(0, 2**256)
         b = random.randint(0, 2**256)
         c = a ^ b

--- a/tests/test_state_circuit.py
+++ b/tests/test_state_circuit.py
@@ -1,9 +1,10 @@
 import traceback
 from typing import Union, List
-from zkevm_specs.state import *
-from zkevm_specs.util import rand_fp, FQ, RLC
 
-randomness = rand_fp()
+from zkevm_specs.state import *
+from zkevm_specs.util import rand_fq, FQ, RLC
+
+randomness = rand_fq()
 r = randomness
 
 # Verify the state circuit with the given data


### PR DESCRIPTION
This PR aims to add mypy for more strict type checking.

Following @ed255's suggestion in [this comment](https://github.com/appliedzkp/zkevm-specs/pull/116#issuecomment-1046723302), it introduces an interface `Expression` providing function `expr` which returns a `FQ`. In this way, we are always comparing number in field, and can avoid unsupported types comparing or integer underflow issues.

It's built upon #110 because #110 removes some unused things, then we don't bother to fix typing of them.

Co-authored-by: @ChihChengLiang
Co-authored-by: @ed255
