### PR TITLE
Don't allow key0 to be 0

### DIFF
--- a/src/zkevm_specs/state.py
+++ b/src/zkevm_specs/state.py
@@ -271,7 +271,7 @@ def check_state_row(row: Row, row_prev: Row, randomness: FQ):
     #
 
     # 0. key0, key1, key3 are in the expected range
-    assert_in_range(row.keys[0], 0, MAX_KEY0)
+    assert_in_range(row.keys[0], 1, MAX_KEY0)
     assert_in_range(row.keys[1], 0, MAX_KEY1)
     assert_in_range(row.keys[3], 0, MAX_KEY3)
 


### PR DESCRIPTION
It being 0 will cause us to hit the unreachable code in line 363 because 0 isn't one of the allowed values for `Tag`. 