### PR TITLE
Use `is_warm` instead of `is_cold` for access list value

### DIFF
--- a/src/zkevm_specs/evm/execution/begin_tx.py
+++ b/src/zkevm_specs/evm/execution/begin_tx.py
@@ -44,12 +44,8 @@ def begin_tx(instruction: Instruction):
     instruction.constrain_gas_left_not_underflow(gas_left)
 
     # Prepare access list of caller and callee
-    instruction.constrain_equal(
-        instruction.add_account_to_access_list(tx_id, tx_caller_address), FQ(1)
-    )
-    instruction.constrain_equal(
-        instruction.add_account_to_access_list(tx_id, tx_callee_address), FQ(1)
-    )
+    instruction.constrain_zero(instruction.add_account_to_access_list(tx_id, tx_caller_address))
+    instruction.constrain_zero(instruction.add_account_to_access_list(tx_id, tx_callee_address))
 
     # Verify transfer
     instruction.transfer_with_gas_fee(

--- a/src/zkevm_specs/evm/execution/storage.py
+++ b/src/zkevm_specs/evm/execution/storage.py
@@ -27,14 +27,14 @@ def sload(instruction: Instruction):
         instruction.stack_push(),
     )
 
-    is_cold = instruction.add_account_storage_to_access_list(
+    is_warm = instruction.add_account_storage_to_access_list(
         tx_id,
         callee_address,
         storage_key,
         reversion_info,
     )
 
-    dynamic_gas_cost = instruction.select(is_cold, FQ(COLD_SLOAD_COST), FQ(WARM_STORAGE_READ_COST))
+    dynamic_gas_cost = instruction.select(is_warm, FQ(WARM_STORAGE_READ_COST), FQ(COLD_SLOAD_COST))
 
     instruction.step_state_transition_in_same_context(
         opcode,
@@ -64,7 +64,7 @@ def sstore(instruction: Instruction):
     )
     instruction.constrain_equal(storage_value, value)
 
-    is_cold = instruction.add_account_storage_to_access_list(
+    is_warm = instruction.add_account_storage_to_access_list(
         tx_id,
         callee_address,
         storage_key,
@@ -126,7 +126,7 @@ def sstore(instruction: Instruction):
             FQ(SSTORE_RESET_GAS),
         ),
     )
-    dynamic_gas_cost = instruction.select(is_cold, warm_case_gas + COLD_SLOAD_COST, warm_case_gas)
+    dynamic_gas_cost = instruction.select(is_warm, warm_case_gas, warm_case_gas + COLD_SLOAD_COST)
 
     instruction.step_state_transition_in_same_context(
         opcode,

--- a/src/zkevm_specs/evm/instruction.py
+++ b/src/zkevm_specs/evm/instruction.py
@@ -611,7 +611,7 @@ class Instruction:
             value=FQ(1),
             reversion_info=reversion_info,
         )
-        return row.value.expr() - row.value_prev.expr()
+        return row.value_prev.expr()
 
     def add_account_storage_to_access_list(
         self,
@@ -628,7 +628,7 @@ class Instruction:
             value=FQ(1),
             reversion_info=reversion_info,
         )
-        return row.value.expr() - row.value_prev.expr()
+        return row.value_prev.expr()
 
     def transfer_with_gas_fee(
         self,


### PR DESCRIPTION
Just realized using `is_warm` as value of access list in real circuit seems more straightforward, so this PR aims to revert the change made in #132, and also update the usage of access list in `BeginTx`.

(to be nitpicking, it should be `is_already_warm` or `is_warm_prev` since it's the previous value, but omitting `already` or `prev` seems fine here)