### PR TITLE
Add tx circuit spec

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,9 @@ python_requires = >=3.9
 install_requires =
     pycryptodome==3.11.0
     py-ecc==6.0.0
+    eth-keys==0.4.0
+    rlp==3.0.0
+    eth-utils==2.0.0
 
 [options.packages.find]
 where = src

--- a/specs/transactions-proof.md
+++ b/specs/transactions-proof.md
@@ -23,8 +23,7 @@ After EIP-155:
 
 Hashed data to sign: `(nonce, gasprice, gas, to, value, data, chain_id, 0, 0)` with `sig_v = {0,1} + CHAIN_ID * 2 + 35`
 
-Where `{0,1}` is the parity of the `y` value of the curve point for which `r`
-is the x-value in the secp256k1 signing process.
+Where `{0,1}` is the parity of the `y` value of the curve point corresponding to the public key in the secp256k1 signing process.
 
 ### Non-Legacy (EIP-2718) type:
 

--- a/specs/transactions-proof.md
+++ b/specs/transactions-proof.md
@@ -51,8 +51,8 @@ For every transaction defined as the parameters `(nonce, gas_price, gas, to, val
   custom rlp encoding gadget, isolated from the rlp encoding used by the MPT
   circuit.
 - The signature message keccak hash verification (step 2) will be done in the
-  keccak circuit; the tx circuit will do a variable number of lookups
-  (depending on the size of `txSignData`) to the keccak table.
+  keccak circuit; the tx circuit will do a single lookup (with the rlp encoded
+  transaction accumulated into a single value using RLC) to the keccak table.
 - The public key recovery from the message and signature (step 3) will be done
   in the ECDSA circuit; the tx circuit will do a lookup to the ECDSA table.
 - The public key keccak hash verification (step 5) will be done in the keccak

--- a/specs/transactions-proof.md
+++ b/specs/transactions-proof.md
@@ -212,6 +212,20 @@ Organizing the table this way allows having the values of `CallerAddress` and
 add copy constraints of these values to cells into another region that performs
 the signature verification and hash lookup.
 
+### Summary of changes
+
+- Skip verification of correct construction of the transaction trie (no MPT table lookups)
+- Skip verification of RLC of transaction to obtain the message to sign
+- Skip verification of hash of RLC of transaction to obtain the hash of the message to sign
+- Add TxSignHash Tag to the tx table (set from public input calculated in L1 smart contract)
+- Instead of verifying ECDSA signatures by doing lookups to an ECDSA table, use ECDSA chip directly.
+  - This requires rearangement of the tx table so that for each transaction we
+    can find its CallerAddress Value and TxSignHash value at fixed offset to do
+    a copy constraint to a signature verification gadget.  For this we move the
+    CallData tags of all transactions to the end of the table, and we define
+    padding at the middle (between the fixed offset region and dynamic offset
+    region) and at the end.
+
 ## Code
 
 Please refer to `src/zkevm-specs/tx.py`.

--- a/specs/transactions-proof.md
+++ b/specs/transactions-proof.md
@@ -44,7 +44,7 @@ For every transaction defined as the parameters `(nonce, gas_price, gas, to, val
 1. `txSignData: bytes = rlp([nonce, gas_price, gas, to, value, data, chain_id, 0, 0])`
 2. `txSignHash: word = keccak(txSignData)`
 3. `sig_parity: {0, 1} = sig_v - 35 - chain_id / 2`
-4. `ecRecover(txSignHash, sig_parity, sig_r, sig_s) = pubKey` or equivalently `verify(txSignHash, sig_r, sig_s, pubKey) = true`
+4. `ecdsa_recover(txSignHash, sig_parity, sig_r, sig_s) = pubKey` or equivalently `verify(txSignHash, sig_r, sig_s, pubKey) = true`
 5. `fromAddress = keccak(pubKey)[-20:]`
 
 - The rlp encoding of transaction parameters (step 1) will be done using a

--- a/specs/transactions-proof.md
+++ b/specs/transactions-proof.md
@@ -1,0 +1,219 @@
+# Transactions proof
+
+The transactions proof verifies each transaction signature, that the merkle
+patricia trie identified by the root `transactionsRoot` contains all the
+transactions (and no more), and makes the transactions data easily accessible
+to the EVM proof via the transactions table.
+
+## Transaction encoding
+
+Different types of transaction encoding exists.  On the first iteration of the zkEVM we will only support Legacy transactions with EIP-155.  We plan to add support for Non-Legacy (EIP-2718) transactions later.
+
+### Legacy type:
+
+```
+rlp([nonce, gasPrice, gas, to, value, data, sig_v, r, s])
+```
+
+Before EIP-155:
+
+Hashed data to sign: `(nonce, gasprice, gas, to, value, data)` with `sig_v = {0,1} + 27`
+
+After EIP-155:
+
+Hashed data to sign: `(nonce, gasprice, gas, to, value, data, chain_id, 0, 0)` with `sig_v = {0,1} + CHAIN_ID * 2 + 35`
+
+Where `{0,1}` is the parity of the `y` value of the curve point for which `r`
+is the x-value in the secp256k1 signing process.
+
+### Non-Legacy (EIP-2718) type:
+
+From https://eips.ethereum.org/EIPS/eip-1559 and https://eips.ethereum.org/EIPS/eip-2718
+
+```
+0x02 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas, destination, amount, data, access_list, signature_y_parity, signature_r, signature_s])
+```
+
+Hashed data to sign: TODO
+
+## Circuit behaviour
+
+Using the following public inputs: `chain_id`, `transactionsRoot`.
+
+For every transaction defined as the parameters `(nonce, gas_price, gas, to, value, data, sig_v, sig_r, sig_s)` and using as public inputs `(nonce, gas_price, gas, to, value, data, from)`, the circuit verifies the following:
+
+1. `txSignData: bytes = rlp([nonce, gas_price, gas, to, value, data, chain_id, 0, 0])`
+2. `txSignHash: word = keccak(txSignData)`
+3. `sig_parity: {0, 1} = sig_v - 35 - chain_id / 2`
+4. `ecRecover(txSignHash, sig_parity, sig_r, sig_s) = pubKey` or equivalently `verify(txSignHash, sig_r, sig_s, pubKey) = true`
+5. `fromAddress = keccak(pubKey)[-20:]`
+
+- The rlp encoding of transaction parameters (step 1) will be done using a
+  custom rlp encoding gadget, isolated from the rlp encoding used by the MPT
+  circuit.
+- The signature message keccak hash verification (step 2) will be done in the
+  keccak circuit; the tx circuit will do a variable number of lookups
+  (depending on the size of `txSignData`) to the keccak table.
+- The public key recovery from the message and signature (step 3) will be done
+  in the ECDSA circuit; the tx circuit will do a lookup to the ECDSA table.
+- The public key keccak hash verification (step 5) will be done in the keccak
+  circuit; the tx circuit will do a lookup to the keccak table.
+
+From this information the circuit builds the TxTable:
+
+Where:
+
+- Gas = gas
+- GasTipCap = 0
+- GasFeeCap = 0
+- CallerAddress = fromAddress
+- CalleeAddress = to
+- IsCreate = `1 if to is None else 0`
+- CallDataLength = len(data)
+- CallData\[$ByteIndex\] = data\[$ByteIndex\]
+
+| 0 TxID | 1 Tag               | 2 Index    | 3 value     |
+| ---    | ---                 | ---        | ---         |
+|        | *TxContextFieldTag* |            |             |
+| $TxID  | Nonce               | 0          | $value: raw |
+| $TxID  | Gas                 | 0          | $value: raw |
+| $TxID  | GasPrice            | 0          | $value: rlc |
+| $TxID  | GasTipCap           | 0          | $value: 0   |
+| $TxID  | GasFeeCap           | 0          | $value: 0   |
+| $TxID  | CallerAddress       | 0          | $value: raw |
+| $TxID  | CalleeAddress       | 0          | $value: raw |
+| $TxID  | IsCreate            | 0          | $value: raw |
+| $TxID  | Value               | 0          | $value: rlc |
+| $TxID  | CallDataLength      | 0          | $value: raw |
+| $TxID  | CallData            | $ByteIndex | $value: raw |
+
+There are some constraints on the shape of the table like:
+
+- For every Tx, each tag must appear exactly once, except for `CallData` which can be repeated but only with sequential `ByteIndex` starting at 0.
+- `TxID` must start at 1 and increase sequentially for each transaction
+- When `Tag` is `CallData`, value must be between 0 and 255
+- A `Start` `Tag` is used as padding at the initial rows, and it must use `TxID = 0`
+
+Since the transaction table is built from public inputs, the verifier (the L1
+smart contract in the zkRollup for example) needs to validate that all rows of
+the table are properly built using the transaction data.  Since the table
+construction is validated outside of the circuit, there's no need to verify the
+same constraints inside of the circuit.
+
+### Transaction Trie
+
+For each transaction, the tx circuit also must prepare the key and value used
+to build the transaction trie.  These keys and values are used in lookups to
+the MPT table in order to verify that a tree built with the key-values
+corresponding to the transactions has the root value `transactionsRoot`.
+
+> By doing lookups to the MPT table, we prove that when we start with an empty
+> MPT, and do a chain of key-value insertions corresponding to each
+> transaction, we reach a Trie with root value `transactionsRoot`.
+
+Each MPT update uses the following parameters:
+
+- Key = `rlp(tx_index)`
+- Value = `rlp([nonce, gas_price, gas, to, value, data, sig_v, r, s])`
+- ValuePrev = `0`
+
+NOTE: The shape of the MPT lookup table for transaction trie update entries is not
+yet defined.
+
+NOTE: The MPT proof used for the Transaction Trie doesn't need deletion support.
+
+`go-ethereum` reference:
+
+- [Transaction Trie Root calculation](https://github.com/ethereum/go-ethereum/blob/70da74e73a182620a09bb0cfbff173e6d65d0518/core/types/hashing.go#L86)
+- [Transaction RLP encoding](https://github.com/ethereum/go-ethereum/blob/70da74e73a182620a09bb0cfbff173e6d65d0518/core/types/transaction.go#L405)
+
+## Circuit Behaviour shortcut 1
+
+For the first implementation of the transaction circuit we will apply
+some shortcut as a simplification.  For each transaction, the following values
+will be provided as valid public inputs (and won't be verified in the circuit):
+
+- `txSignHash` (this implies that the circuit doesn't need to calculate `txSignData`).
+
+In particular, for the zkRollup, we will calculate the `txSignData` and
+`txSignHash` in the L1 contract as part of the verification process.
+
+We will also skip the verification of correctly constructing the Transaction
+Trie.  Currently the MPT circuit is being specified and implemented for the
+need of the Account Storage Tries and State Trie updates, which implies some
+difference in usage compared to the Tx Circuit:
+
+1. The lookup table needs to be defined in the MPT for these Tx Circuit
+   particular lookups (which are separate from the State Trie and Account
+   Storage Lookups).  Here we're building a trie from scratch and getting it's
+   root.
+2. While the State Trie and Account Storage Trie inserts use leafs that are
+   bounded in size, for the Transactions Trie, the leafs are the RLP of the
+   Transaction, which contain a variable size calldata.  This means that a MPT
+   update can't be done with a single lookup.  Also the MPT circuit needs to
+   accomodate variable length leaf values.
+
+Once the first iteration of the MPT (the one that fulfills the needs of the
+State Circuit lookups) is finished, we'll work on this.
+
+For this implementation, the Tx Table is extended to look like this:
+
+| 0 TxID | 1 Tag               | 2 Index    | 3 value     |
+| ---    | ---                 | ---        | ---         |
+|        | *TxContextFieldTag* |            |             |
+| $TxID  | Nonce               | 0          | $value: raw |
+| $TxID  | Gas                 | 0          | $value: raw |
+| $TxID  | GasPrice            | 0          | $value: rlc |
+| $TxID  | GasTipCap           | 0          | $value: 0   |
+| $TxID  | GasFeeCap           | 0          | $value: 0   |
+| $TxID  | CallerAddress       | 0          | $value: raw |
+| $TxID  | CalleeAddress       | 0          | $value: raw |
+| $TxID  | IsCreate            | 0          | $value: raw |
+| $TxID  | Value               | 0          | $value: rlc |
+| $TxID  | CallDataLength      | 0          | $value: raw |
+| $TxID  | TxSignHash          |            | $value: rlc |
+| $TxID  | CallData            | $ByteIndex | $value: raw |
+| $TxID  | Pad                 | 0          | 0           |
+
+For the ECDSA signature verification, instead of doing lookups to the ECDSA table we'll just use an ECDSA verification gadget for each transaction.  Since each transaction uses a variable number of rows due to the variable length CallData, we'll rearrange the table so that each transaction starts at a fixed offset like this (by moving all the CallData rows at the end):
+
+For each transaction:
+
+| 0 TxID | 1 Tag               | 2 Index    | 3 value     |
+| ---    | ---                 | ---        | ---         |
+|        | *TxContextFieldTag* |            |             |
+| $TxID  | Nonce               | 0          | $value: raw |
+| $TxID  | Gas                 | 0          | $value: raw |
+| $TxID  | GasPrice            | 0          | $value: rlc |
+| $TxID  | GasTipCap           | 0          | $value: 0   |
+| $TxID  | GasFeeCap           | 0          | $value: 0   |
+| $TxID  | CallerAddress       | 0          | $value: raw |
+| $TxID  | CalleeAddress       | 0          | $value: raw |
+| $TxID  | IsCreate            | 0          | $value: raw |
+| $TxID  | Value               | 0          | $value: rlc |
+| $TxID  | CallDataLength      | 0          | $value: raw |
+| $TxID  | TxSignHash          |            | $value: rlc |
+
+This structure is repeated `MAX_TXS` times.  When the number of transactions is
+less than `MAX_TXS`, the rows corresponding to unused transactions will use the
+`Pad` tag.
+
+Then the table continues: for each transaction:
+
+| 0 TxID | 1 Tag               | 2 Index    | 3 value     |
+| ---    | ---                 | ---        | ---         |
+|        | *TxContextFieldTag* |            |             |
+| $TxID  | CallData            | $ByteIndex | $value: raw |
+
+These rows are repeated `MAX_CALLDATA_BYTES` times.  When the total numer of
+bytes from all transactions' call data is less than `MAX_CALLDATA_BYTES`, the
+rows corresponding to unused transactions will use the `Pad` tag.
+
+Organizing the table this way allows having the values of `CallerAddress` and
+`TxSignHash` for each transaction at a fixed offset.  This makes it possible to
+add copy constraints of these values to cells into another region that performs
+the signature verification and hash lookup.
+
+## Code
+
+Please refer to `src/zkevm-specs/tx.py`.

--- a/specs/transactions-proof.md
+++ b/specs/transactions-proof.md
@@ -91,7 +91,6 @@ There are some constraints on the shape of the table like:
 - For every Tx, each tag must appear exactly once, except for `CallData` which can be repeated but only with sequential `ByteIndex` starting at 0.
 - `TxID` must start at 1 and increase sequentially for each transaction
 - When `Tag` is `CallData`, value must be between 0 and 255
-- A `Start` `Tag` is used as padding at the initial rows, and it must use `TxID = 0`
 
 Since the transaction table is built from public inputs, the verifier (the L1
 smart contract in the zkRollup for example) needs to validate that all rows of

--- a/src/zkevm_specs/tx.py
+++ b/src/zkevm_specs/tx.py
@@ -210,11 +210,15 @@ class SignVerifyGadget:
         self.ecdsa_chip.verify(is_enabled, assert_msg)
 
 
+class Witness(NamedTuple):
+    rows: List[Row]  # Transaction table rows
+    keccak_table: KeccakTable
+    sign_verifications: List[SignVerifyGadget]
+
+
 @is_circuit_code
 def verify_circuit(
-    rows: List[Row],
-    sign_verifications: List[SignVerifyGadget],
-    keccak_table: KeccakTable,
+    witness: Witness,
     MAX_TXS: int,
     MAX_CALLDATA_BYTES: int,
     randomness: FQ,
@@ -223,6 +227,9 @@ def verify_circuit(
     Entry level circuit verification function
     """
 
+    rows = witness.rows
+    sign_verifications = witness.sign_verifications
+    keccak_table = witness.keccak_table
     for tx_index in range(MAX_TXS):
         assert_msg = f"Constraints failed for tx_index = {tx_index}"
         tx_row_index = tx_index * Tag.TxSignHash
@@ -306,12 +313,6 @@ def tx2witness(
         rows.append(Row(tx_id, FQ(Tag.CallData), FQ(byte_index), FQ(byte)))
 
     return (rows, sign_verification)
-
-
-class Witness(NamedTuple):
-    rows: List[Row]  # Transaction table rows
-    keccak_table: KeccakTable
-    sign_verifications: List[SignVerifyGadget]
 
 
 def txs2witness(

--- a/src/zkevm_specs/tx.py
+++ b/src/zkevm_specs/tx.py
@@ -56,7 +56,12 @@ class KeccakTable:
     def add(self, input: bytes, randomness: FQ):
         output = keccak(input)
         self.table.add(
-            (FQ(1), RLC(input, randomness).value, FQ(len(input)), RLC(output, randomness).value)
+            (
+                FQ(1),
+                RLC(bytes(reversed(input)), randomness).value,
+                FQ(len(input)),
+                RLC(output, randomness).value,
+            )
         )
 
     def lookup(self, is_enabled: FQ, input_rlc: FQ, input_len: FQ, output_rlc: FQ, assert_msg: str):
@@ -193,7 +198,7 @@ class SignVerifyGadget:
         )
         keccak_table.lookup(
             is_enabled,
-            RLC(pub_key_bytes, randomness).value,
+            RLC(bytes(reversed(pub_key_bytes)), randomness).value,
             FQ(64) * is_enabled,
             self.pub_key_hash.value,
             assert_msg,

--- a/src/zkevm_specs/tx.py
+++ b/src/zkevm_specs/tx.py
@@ -45,6 +45,10 @@ class Row:
         self.value = value
 
 
+# TODO: Review if the keccak table layout used here matches the final keccak
+# lookup table layout in the spec.
+# - Keccak input spec PR https://github.com/appliedzkp/zkevm-specs/pull/147
+# - Tracking issue https://github.com/appliedzkp/zkevm-specs/issues/158
 class KeccakTable:
     # The columns are: (is_enabled, input_rlc, input_len, output_rlc)
     table: Set[Tuple[FQ, FQ, FQ, FQ]]

--- a/src/zkevm_specs/tx.py
+++ b/src/zkevm_specs/tx.py
@@ -217,7 +217,6 @@ def verify_circuit(
     keccak_table: KeccakTable,
     MAX_TXS: int,
     MAX_CALLDATA_BYTES: int,
-    chain_id: U64,
     randomness: FQ,
 ) -> None:
     """

--- a/src/zkevm_specs/tx.py
+++ b/src/zkevm_specs/tx.py
@@ -1,0 +1,364 @@
+from .encoding import U8, is_circuit_code
+from typing import NamedTuple, Tuple, List, Sequence, Set
+from .util import FQ, RLC, U160, U256, U64
+from enum import IntEnum, auto
+from eth_keys import KeyAPI  # type: ignore
+import rlp  # type: ignore
+from eth_utils import keccak
+
+
+class Tag(IntEnum):
+    """
+    Tag used as second key in the Tx Circuit Rows to "select" the transaction field target.
+    Can be encoded in 4 bits.
+    """
+
+    Nonce = 1
+    Gas = 2
+    GasPrice = 3
+    GasTipCap = 4
+    GasFeeCap = 5
+    CallerAddress = 6
+    CalleeAddress = 7
+    IsCreate = 8
+    Value = 9
+    CallDataLength = 10
+    TxSignHash = 11
+    CallData = 12
+    Pad = 13
+
+
+class Row:
+    """
+    Tx circuit row
+    """
+
+    tx_id: FQ
+    tag: FQ
+    index: FQ
+    value: FQ
+
+    def __init__(self, tx_id: FQ, tag: FQ, index: FQ, value: FQ):
+        self.tx_id = tx_id
+        self.tag = tag
+        self.index = index
+        self.value = value
+
+
+class KeccakTable:
+    # The columns are: (is_enabled, input_rlc, input_len, output_rlc)
+    table: Set[Tuple[FQ, FQ, FQ, FQ]]
+
+    def __init__(self):
+        self.table = set()
+        self.table.add((FQ(0), FQ(0), FQ(0), FQ(0)))  # Add all 0s row
+
+    def add(self, input: bytes, randomness: FQ):
+        output = keccak(input)
+        self.table.add(
+            (FQ(1), RLC(input, randomness).value, FQ(len(input)), RLC(output, randomness).value)
+        )
+
+    def lookup(self, is_enabled: FQ, input_rlc: FQ, input_len: FQ, output_rlc: FQ, assert_msg: str):
+        assert (is_enabled, input_rlc, input_len, output_rlc) in self.table, (
+            f"{assert_msg}: {(is_enabled, input_rlc, input_len, output_rlc)} "
+            + "not found in the lookup table"
+        )
+
+
+class WrongFieldInteger:
+    """
+    Wrong Field arithmetic Integer, representing the implementation at
+    https://github.com/appliedzkp/halo2wrong/blob/master/integer/src/integer.rs
+    """
+
+    limbs: bytes  # Little-Endian bytes
+
+    def __init__(self, value: int) -> None:
+        self.limbs = value.to_bytes(32, "little")
+
+
+class Secp256k1BaseField(WrongFieldInteger):
+    """
+    Secp256k1 Base Field.
+    """
+
+    def __init__(self, value: int) -> None:
+        WrongFieldInteger.__init__(self, value)
+
+
+class Secp256k1ScalarField(WrongFieldInteger):
+    """
+    Secp256k1 Scalar Field.
+    """
+
+    def __init__(self, value: int) -> None:
+        WrongFieldInteger.__init__(self, value)
+
+
+class ECDSAVerifyChip:
+    """
+    ECDSA Signature Verification Chip.  This represents an ECDSA signature
+    verification Chip as implemented in
+    https://github.com/appliedzkp/halo2wrong/blob/master/ecdsa/src/ecdsa.rs
+    """
+
+    signature: Tuple[Secp256k1ScalarField, Secp256k1ScalarField]
+    pub_key: Tuple[Secp256k1BaseField, Secp256k1BaseField]
+    msg_hash: Secp256k1ScalarField
+
+    def __init__(
+        self,
+        signature: Tuple[Secp256k1ScalarField, Secp256k1ScalarField],
+        pub_key: Tuple[Secp256k1BaseField, Secp256k1BaseField],
+        msg_hash: Secp256k1ScalarField,
+    ) -> None:
+        self.signature = signature
+        self.pub_key = pub_key
+        self.msg_hash = msg_hash
+
+    @classmethod
+    def assign(cls, signature: KeyAPI.Signature, pub_key: KeyAPI.PublicKey, msg_hash: bytes):
+        self_signature = (Secp256k1ScalarField(signature.r), Secp256k1ScalarField(signature.s))
+        pub_key_bytes = pub_key.to_bytes()
+        pub_key_bytes_x, pub_key_bytes_y = pub_key_bytes[:32], pub_key_bytes[32:]
+        pub_key_x = int.from_bytes(pub_key_bytes_x, "big")
+        pub_key_y = int.from_bytes(pub_key_bytes_y, "big")
+        self_pub_key = (Secp256k1BaseField(pub_key_x), Secp256k1BaseField(pub_key_y))
+        self_msg_hash = Secp256k1ScalarField(int.from_bytes(msg_hash, "big"))
+        return cls(self_signature, self_pub_key, self_msg_hash)
+
+    def verify(self, is_enabled: FQ, assert_msg: str):
+        msg_hash = bytes(reversed(self.msg_hash.limbs))
+        sig_r = int.from_bytes(self.signature[0].limbs, "little")
+        sig_s = int.from_bytes(self.signature[1].limbs, "little")
+        signature = KeyAPI.Signature(vrs=[0, sig_r, sig_s])
+        public_key = KeyAPI.PublicKey(
+            bytes(reversed(self.pub_key[0].limbs)) + bytes(reversed(self.pub_key[1].limbs))
+        )
+        if is_enabled == 1:
+            assert KeyAPI().ecdsa_verify(
+                msg_hash, signature, public_key
+            ), f"{assert_msg}: ecdsa_verify failed"
+
+
+class SignVerifyGadget:
+    """
+    Auxiliary Gadget to verify a that a message hash is signed by the public
+    key corresponding to an Ethereum Address.
+    """
+
+    pub_key_hash: RLC
+    address: FQ
+    msg_hash_rlc: FQ  # Set to 0 to disable verification check
+    ecdsa_chip: ECDSAVerifyChip
+
+    def __init__(
+        self,
+        pub_key_hash: RLC,
+        address: FQ,
+        msg_hash_rlc: FQ,
+        ecdsa_chip: ECDSAVerifyChip,
+    ) -> None:
+        self.pub_key_hash = pub_key_hash
+        self.address = address
+        self.msg_hash_rlc = msg_hash_rlc
+        self.ecdsa_chip = ecdsa_chip
+
+    @classmethod
+    def assign(
+        cls, signature: KeyAPI.Signature, pub_key: KeyAPI.PublicKey, msg_hash: bytes, randomness: FQ
+    ):
+        pub_key_hash = keccak(pub_key.to_bytes())
+        self_pub_key_hash = RLC(pub_key_hash, randomness)
+        self_address = FQ(int.from_bytes(pub_key_hash[-20:], "big"))
+        self_msg_hash_rlc = RLC(int.from_bytes(msg_hash, "big"), randomness).value
+        self_ecdsa_chip = ECDSAVerifyChip.assign(signature, pub_key, msg_hash)
+        return cls(self_pub_key_hash, self_address, self_msg_hash_rlc, self_ecdsa_chip)
+
+    def verify(self, keccak_table: KeccakTable, randomness: FQ, assert_msg: str):
+        is_enabled = FQ(1 - (self.msg_hash_rlc == 0))  # 1 - is_zero(self.msg_hash_rlc)
+
+        # 0. Verify that the first 20 bytes of the pub_key_hash equal the address
+        addr_expr = FQ.linear_combine(list(reversed(self.pub_key_hash.le_bytes[-20:])), FQ(2**8))
+        assert (
+            addr_expr == self.address
+        ), f"{assert_msg}: {hex(addr_expr.n)} != {hex(self.address.n)}"
+
+        # 1. Verify that keccak(pub_key_bytes) = pub_key_hash by keccak table
+        # lookup, where pub_key_bytes is built from the pub_key in the
+        # ecdsa_chip
+        pub_key_bytes = bytes(reversed(self.ecdsa_chip.pub_key[0].limbs)) + bytes(
+            reversed(self.ecdsa_chip.pub_key[1].limbs)
+        )
+        keccak_table.lookup(
+            is_enabled,
+            RLC(pub_key_bytes, randomness).value,
+            FQ(64) * is_enabled,
+            self.pub_key_hash.value,
+            assert_msg,
+        )
+
+        # 2. Verify that the signed message in the ecdsa_chip with RLC encoding
+        # corresponds to msg_hash_rlc
+        msg_hash_rlc_expr = FQ.linear_combine(self.ecdsa_chip.msg_hash.limbs, randomness)
+        assert (
+            msg_hash_rlc_expr == self.msg_hash_rlc
+        ), f"{assert_msg}: {hex(msg_hash_rlc_expr.n)} != {hex(self.msg_hash_rlc.n)}"
+
+        # Verify the ECDSA signature
+        self.ecdsa_chip.verify(is_enabled, assert_msg)
+
+
+@is_circuit_code
+def verify_circuit(
+    rows: List[Row],
+    sign_verifications: List[SignVerifyGadget],
+    keccak_table: KeccakTable,
+    MAX_TXS: int,
+    MAX_CALLDATA_BYTES: int,
+    chain_id: U64,
+    randomness: FQ,
+) -> None:
+    """
+    Entry level circuit verification function
+    """
+
+    for tx_index in range(MAX_TXS):
+        assert_msg = f"Constraints failed for tx_index = {tx_index}"
+        tx_row_index = tx_index * Tag.TxSignHash
+        caller_addr_index = tx_row_index + Tag.CallerAddress - 1
+        tx_msg_hash_index = tx_row_index + Tag.TxSignHash - 1
+
+        # SignVerifyGadget constraint verification.  Padding txs rows contain
+        # 0 in all values.  The SignVerifyGadget skips the verification when
+        # the msg_hash_rlc == 0.
+        sign_verifications[tx_index].verify(keccak_table, randomness, assert_msg)
+
+        # 0. Copy constraints using fixed offsets between the tx rows and the SignVerifyGadget
+        assert rows[caller_addr_index].value == sign_verifications[tx_index].address, (
+            f"{assert_msg}: {hex(rows[caller_addr_index].value.n)} != "
+            + f"{hex(sign_verifications[tx_index].address.n)}"
+        )
+        assert rows[tx_msg_hash_index].value == sign_verifications[tx_index].msg_hash_rlc, (
+            f"{assert_msg}: {hex(rows[tx_msg_hash_index].value.n)} != "
+            + f"{hex(sign_verifications[tx_index].msg_hash_rlc.n)}"
+        )
+
+    # Remaining rows contain CallData.  Those rows don't have any circuit constraint.
+
+
+class Transaction(NamedTuple):
+    """
+    Ethereum Transaction
+    """
+
+    nonce: U64
+    gas_price: U256
+    gas: U64
+    to: U160
+    value: U256
+    data: bytes
+    sig_v: U64
+    sig_r: U256
+    sig_s: U256
+
+
+def tx2witness(
+    index: int, tx: Transaction, chain_id: U64, randomness: FQ, keccak_table: KeccakTable
+) -> Tuple[List[Row], SignVerifyGadget]:
+    """
+    Generate the witness data for a single transaction: generate the tx table
+    rows, insert the pub_key_bytes entry in the keccak_table and assign the
+    SignVerifyGadget.
+    """
+
+    tx_msg = rlp.encode([tx.nonce, tx.gas_price, tx.gas, tx.to, tx.value, tx.data, chain_id, 0, 0])
+    tx_msg_hash = keccak(tx_msg)
+
+    sig_parity = tx.sig_v - 35 - chain_id * 2
+    sig = KeyAPI.Signature(vrs=(sig_parity, tx.sig_r, tx.sig_s))
+
+    pk = sig.recover_public_key_from_msg_hash(tx_msg_hash)
+    pk_bytes = pk.to_bytes()
+    keccak_table.add(pk_bytes, randomness)
+    pk_hash = keccak(pk.to_bytes())
+    addr = pk_hash[-20:]
+
+    sign_verification = SignVerifyGadget.assign(sig, pk, tx_msg_hash, randomness)
+
+    tx_id = FQ(index + 1)
+    rows: List[Row] = []
+    rows.append(Row(tx_id, FQ(Tag.Nonce), FQ(0), FQ(tx.nonce)))
+    rows.append(Row(tx_id, FQ(Tag.Gas), FQ(0), FQ(tx.gas)))
+    rows.append(Row(tx_id, FQ(Tag.GasPrice), FQ(0), RLC(tx.gas_price, randomness).value))
+    rows.append(Row(tx_id, FQ(Tag.GasTipCap), FQ(0), FQ(0)))
+    rows.append(Row(tx_id, FQ(Tag.GasFeeCap), FQ(0), FQ(0)))
+    rows.append(Row(tx_id, FQ(Tag.CallerAddress), FQ(0), FQ(int.from_bytes(addr, "big"))))
+    rows.append(Row(tx_id, FQ(Tag.CalleeAddress), FQ(0), FQ(tx.to)))
+    rows.append(Row(tx_id, FQ(Tag.IsCreate), FQ(0), FQ(1) if tx.to == FQ(0) else FQ(0)))
+    rows.append(Row(tx_id, FQ(Tag.Value), FQ(0), RLC(tx.value, randomness).value))
+    rows.append(Row(tx_id, FQ(Tag.CallDataLength), FQ(0), FQ(len(tx.data))))
+    tx_msg_hash_rlc = RLC(int.from_bytes(tx_msg_hash, "big"), randomness).value
+    rows.append(Row(tx_id, FQ(Tag.TxSignHash), FQ(0), tx_msg_hash_rlc))
+    for byte_index, byte in enumerate(tx.data):
+        rows.append(Row(tx_id, FQ(Tag.CallData), FQ(byte_index), FQ(byte)))
+
+    return (rows, sign_verification)
+
+
+class Witness(NamedTuple):
+    rows: List[Row]  # Transaction table rows
+    keccak_table: KeccakTable
+    sign_verifications: List[SignVerifyGadget]
+
+
+def txs2witness(
+    txs: List[Transaction], chain_id: U64, MAX_TXS: int, MAX_CALLDATA_BYTES: int, randomness: FQ
+) -> Witness:
+    """
+    Generate the complete witness of the transactions for a fixed size circuit.
+    """
+    assert len(txs) <= MAX_TXS
+
+    keccak_table = KeccakTable()
+    sign_verifications: List[SignVerifyGadget] = []
+    tx_fixed_rows: List[Row] = []  # Accumulate fixed rows of each tx
+    tx_dyn_rows: List[Row] = []  # Accumulate CallData rows of each tx
+    for index, tx in enumerate(txs):
+        tx_rows, sign_verification = tx2witness(index, tx, chain_id, randomness, keccak_table)
+        sign_verifications.append(sign_verification)
+        for row in tx_rows:
+            if row.tag == Tag.CallData:
+                tx_dyn_rows.append(row)
+            else:
+                tx_fixed_rows.append(row)
+
+    assert len(tx_dyn_rows) <= MAX_CALLDATA_BYTES
+
+    # Fill all the rows in the fixed region to reach MAX_TXS * Tag.TxSignHash
+    # with pad rows.  And fill all the rows in the dynamic region to reach
+    # MAX_CALLDATA_BYTES with pad rows.
+    rows = (
+        tx_fixed_rows
+        + [Row(FQ(0), FQ(Tag.Pad), FQ(0), FQ(0))] * (MAX_TXS - len(txs)) * Tag.TxSignHash
+        + tx_dyn_rows
+        + [Row(FQ(0), FQ(Tag.Pad), FQ(0), FQ(0))] * (MAX_CALLDATA_BYTES - len(tx_dyn_rows))
+    )
+
+    empty_ecdsa_chip = ECDSAVerifyChip(
+        (Secp256k1ScalarField(0), Secp256k1ScalarField(0)),
+        (Secp256k1BaseField(0), Secp256k1BaseField(0)),
+        Secp256k1ScalarField(0),
+    )
+    empty_sign_verification = SignVerifyGadget(
+        RLC(0, randomness),
+        FQ(0),
+        FQ(0),
+        empty_ecdsa_chip,
+    )
+    # Fill the rest of sign_verifications with the witnessess assigned to 0 to
+    # disable the verification.
+    sign_verifications = sign_verifications + [empty_sign_verification] * (MAX_TXS - len(txs))
+
+    return Witness(rows, keccak_table, sign_verifications)

--- a/tests/test_tx_circuit.py
+++ b/tests/test_tx_circuit.py
@@ -50,9 +50,7 @@ def verify(
     ok = True
     if success:
         verify_circuit(
-            witness.rows,
-            witness.sign_verifications,
-            witness.keccak_table,
+            witness,
             MAX_TXS,
             MAX_CALLDATA_BYTES,
             randomness,
@@ -60,9 +58,7 @@ def verify(
     else:
         try:
             verify_circuit(
-                witness.rows,
-                witness.sign_verifications,
-                witness.keccak_table,
+                witness,
                 MAX_TXS,
                 MAX_CALLDATA_BYTES,
                 randomness,

--- a/tests/test_tx_circuit.py
+++ b/tests/test_tx_circuit.py
@@ -55,7 +55,6 @@ def verify(
             witness.keccak_table,
             MAX_TXS,
             MAX_CALLDATA_BYTES,
-            chain_id,
             randomness,
         )
     else:
@@ -66,7 +65,6 @@ def verify(
                 witness.keccak_table,
                 MAX_TXS,
                 MAX_CALLDATA_BYTES,
-                chain_id,
                 randomness,
             )
         except AssertionError as e:

--- a/tests/test_tx_circuit.py
+++ b/tests/test_tx_circuit.py
@@ -14,9 +14,11 @@ def sign_tx(sk: keys.PrivateKey, tx: Transaction, chain_id: U64) -> Transaction:
     """
     Return a copy of the transaction signed by sk
     """
-    tx_msg = rlp.encode([tx.nonce, tx.gas_price, tx.gas, tx.to, tx.value, tx.data, chain_id, 0, 0])
-    tx_msg_hash = keccak(tx_msg)
-    sig = sk.sign_msg_hash(tx_msg_hash)
+    tx_sign_data = rlp.encode(
+        [tx.nonce, tx.gas_price, tx.gas, tx.to, tx.value, tx.data, chain_id, 0, 0]
+    )
+    tx_sign_hash = keccak(tx_sign_data)
+    sig = sk.sign_msg_hash(tx_sign_hash)
     sig_v = sig.v + chain_id * 2 + 35
     sig_r = sig.r
     sig_s = sig.s

--- a/tests/test_tx_circuit.py
+++ b/tests/test_tx_circuit.py
@@ -1,0 +1,204 @@
+import traceback
+from typing import Union, List
+from eth_keys import keys
+from eth_utils import keccak
+import rlp
+from zkevm_specs.tx import *
+from zkevm_specs.util import rand_fq, FQ, RLC, U64
+
+randomness = rand_fq()
+r = randomness
+
+
+def sign_tx(sk: keys.PrivateKey, tx: Transaction, chain_id: U64) -> Transaction:
+    """
+    Return a copy of the transaction signed by sk
+    """
+    tx_msg = rlp.encode([tx.nonce, tx.gas_price, tx.gas, tx.to, tx.value, tx.data, chain_id, 0, 0])
+    tx_msg_hash = keccak(tx_msg)
+    sig = sk.sign_msg_hash(tx_msg_hash)
+    sig_v = sig.v + chain_id * 2 + 35
+    sig_r = sig.r
+    sig_s = sig.s
+    return Transaction(
+        tx.nonce, tx.gas_price, tx.gas, tx.to, tx.value, tx.data, sig_v, sig_r, sig_s
+    )
+
+
+def verify(
+    txs_or_witness: Union[List[Transaction], Witness],
+    MAX_TXS: int,
+    MAX_CALLDATA_BYTES: int,
+    chain_id: U64,
+    randomness: FQ,
+    success: bool = True,
+):
+    """
+    Verify the circuit with the assigned witness (or the witness calculated
+    from the transactions).  If `success` is False, expect the verification to
+    fail.
+    """
+    witness = txs_or_witness
+    if isinstance(txs_or_witness, Witness):
+        pass
+    else:
+        witness = txs2witness(txs_or_witness, chain_id, MAX_TXS, MAX_CALLDATA_BYTES, randomness)
+    assert len(witness.rows) == MAX_TXS * Tag.TxSignHash + MAX_CALLDATA_BYTES
+    assert len(witness.sign_verifications) == MAX_TXS
+    ok = True
+    if success:
+        verify_circuit(
+            witness.rows,
+            witness.sign_verifications,
+            witness.keccak_table,
+            MAX_TXS,
+            MAX_CALLDATA_BYTES,
+            chain_id,
+            randomness,
+        )
+    else:
+        try:
+            verify_circuit(
+                witness.rows,
+                witness.sign_verifications,
+                witness.keccak_table,
+                MAX_TXS,
+                MAX_CALLDATA_BYTES,
+                chain_id,
+                randomness,
+            )
+        except AssertionError as e:
+            ok = False
+    assert ok == success
+
+
+def test_ecdsa_verify_chip():
+    sk = keys.PrivateKey(b"\x02" * 32)
+    pk = sk.public_key
+    msg_hash = b"\xae" * 32
+    sig = sk.sign_msg_hash(msg_hash)
+
+    ecdsa_chip = ECDSAVerifyChip.assign(sig, pk, msg_hash)
+    ecdsa_chip.verify(is_enabled=FQ(1), assert_msg="ecdsa verification failed")
+
+
+def test_tx2witness():
+    sk = keys.PrivateKey(b"\x01" * 32)
+    pk = sk.public_key
+    addr = pk.to_canonical_address()
+
+    chain_id = 23
+
+    nonce = 543
+    gas_price = 1234
+    gas = 987654
+    to = 0x12345678
+    value = 0x1029384756
+    data = bytes([0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99])
+
+    tx = Transaction(nonce, gas_price, gas, to, value, data, 0, 0, 0)
+    tx = sign_tx(sk, tx, chain_id)
+    keccak_table = KeccakTable()
+    rows, sign_verification = tx2witness(0, tx, chain_id, r, keccak_table)
+    for row in rows:
+        print(row)
+        if row.tag == Tag.CallerAddress:
+            assert addr == row.value.n.to_bytes(20, "big")
+
+
+def gen_tx(i: int, sk: keys.PrivateKey, to: int, chain_id) -> Transaction:
+    nonce = 300 + i
+    gas_price = 1000 + i * 2
+    gas = 20000 + i * 3
+    value = 0x30000 + i * 4
+    data = bytes([i] * i)
+
+    tx = Transaction(nonce, gas_price, gas, to, value, data, 0, 0, 0)
+    tx = sign_tx(sk, tx, chain_id)
+    return tx
+
+
+def test_verify():
+    MAX_TXS = 20
+    MAX_CALLDATA_BYTES = 300
+    NUM_TXS = 16
+    chain_id = 1337
+    sks = [keys.PrivateKey(bytes([byte + 1]) * 32) for byte in range(NUM_TXS)]
+
+    txs: List[Transaction] = []
+    keccak_table = KeccakTable()
+    for i, sk in enumerate(sks):
+        to = int.from_bytes(sks[(i + 1) % len(sks)].public_key.to_canonical_address(), "big")
+        tx = gen_tx(i, sk, to, chain_id)
+        txs.append(tx)
+
+    witness = txs2witness(txs, chain_id, MAX_TXS, MAX_CALLDATA_BYTES, r)
+    verify(witness, MAX_TXS, MAX_CALLDATA_BYTES, chain_id, r)
+
+
+def gen_valid_witness() -> Tuple[Witness, U64, int, int]:
+    MAX_TXS = 5
+    MAX_CALLDATA_BYTES = 16
+    NUM_TXS = 3
+    chain_id = 1337
+
+    sks = [keys.PrivateKey(bytes([byte + 1]) * 32) for byte in range(NUM_TXS)]
+
+    txs: List[Transaction] = []
+    keccak_table = KeccakTable()
+    for i, sk in enumerate(sks):
+        to = int.from_bytes(sks[(i + 1) % len(sks)].public_key.to_canonical_address(), "big")
+        tx = gen_tx(i, sk, to, chain_id)
+        txs.append(tx)
+
+    witness = txs2witness(txs, chain_id, MAX_TXS, MAX_CALLDATA_BYTES, r)
+    return witness, chain_id, MAX_TXS, MAX_CALLDATA_BYTES
+
+
+def test_bad_keccak():
+    witness, chain_id, MAX_TXS, MAX_CALLDATA_BYTES = gen_valid_witness()
+    # Set empty keccak lookup table
+    witness = Witness(witness.rows, KeccakTable(), witness.sign_verifications)
+    verify(witness, MAX_TXS, MAX_CALLDATA_BYTES, chain_id, r, success=False)
+
+
+def test_bad_signature():
+    witness, chain_id, MAX_TXS, MAX_CALLDATA_BYTES = gen_valid_witness()
+    sign_verifications = witness.sign_verifications
+    sign_verifications[0].ecdsa_chip.signature = (Secp256k1ScalarField(1), Secp256k1ScalarField(2))
+    witness = Witness(witness.rows, witness.keccak_table, sign_verifications)
+    verify(witness, MAX_TXS, MAX_CALLDATA_BYTES, chain_id, r, success=False)
+
+
+def test_bad_address():
+    witness, chain_id, MAX_TXS, MAX_CALLDATA_BYTES = gen_valid_witness()
+    sign_verifications = witness.sign_verifications
+    sign_verifications[0].address = FQ(1234)
+    witness = Witness(witness.rows, witness.keccak_table, sign_verifications)
+    verify(witness, MAX_TXS, MAX_CALLDATA_BYTES, chain_id, r, success=False)
+
+
+def test_bad_msg_hash():
+    witness, chain_id, MAX_TXS, MAX_CALLDATA_BYTES = gen_valid_witness()
+    sign_verifications = witness.sign_verifications
+    sign_verifications[0].msg_hash_rlc = FQ(4567)
+    witness = Witness(witness.rows, witness.keccak_table, sign_verifications)
+    verify(witness, MAX_TXS, MAX_CALLDATA_BYTES, chain_id, r, success=False)
+
+
+def test_bad_addr_copy():
+    witness, chain_id, MAX_TXS, MAX_CALLDATA_BYTES = gen_valid_witness()
+    rows = witness.rows
+    row_addr_offset = 0 * Tag.TxSignHash + Tag.CallerAddress - 1
+    rows[row_addr_offset].value = FQ(1213)
+    witness = Witness(rows, witness.keccak_table, witness.sign_verifications)
+    verify(witness, MAX_TXS, MAX_CALLDATA_BYTES, chain_id, r, success=False)
+
+
+def test_bad_sign_hash_copy():
+    witness, chain_id, MAX_TXS, MAX_CALLDATA_BYTES = gen_valid_witness()
+    rows = witness.rows
+    row_hash_offset = 0 * Tag.TxSignHash + Tag.TxSignHash - 1
+    rows[row_hash_offset].value = FQ(2324)
+    witness = Witness(rows, witness.keccak_table, witness.sign_verifications)
+    verify(witness, MAX_TXS, MAX_CALLDATA_BYTES, chain_id, r, success=False)

--- a/tests/test_tx_circuit.py
+++ b/tests/test_tx_circuit.py
@@ -97,7 +97,6 @@ def test_tx2witness():
     keccak_table = KeccakTable()
     rows, sign_verification = tx2witness(0, tx, chain_id, r, keccak_table)
     for row in rows:
-        print(row)
         if row.tag == Tag.CallerAddress:
             assert addr == row.value.n.to_bytes(20, "big")
 


### PR DESCRIPTION
The python spec corresponds to the first iteration of the transaction circuit, where we take some shortcuts described in the markdown document.  In particular
- The RLP of the transaction without signature is done outside of the circuit
- The hash of the RLP of the transaction without signature is done outside of the circuit, and is added into the transaction table so that the circuit can verify the signature.