### PR TITLE
Update black version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,5 +29,5 @@ where = src
 test =
     pytest >= 7.0.0
 lint =
-    black >= 22.1.0
+    black >= 22.3.0
     mypy >= 0.931


### PR DESCRIPTION
There's a bug in the `black` that blocks the lint check in the CI (see [log](https://github.com/appliedzkp/zkevm-specs/runs/5725937215?check_suite_focus=true)). The bug is fixed in the `black` v22.3 (see [reference](https://github.com/psf/black/issues/2969)).