### PR TITLE
Fix tx circuit RLC usage with 64 bytes input

### DIFF
--- a/src/zkevm_specs/tx.py
+++ b/src/zkevm_specs/tx.py
@@ -62,7 +62,7 @@ class KeccakTable:
         self.table.add(
             (
                 FQ(1),
-                RLC(bytes(reversed(input)), randomness).value,
+                RLC(bytes(reversed(input)), randomness, n_bytes=64).value,
                 FQ(len(input)),
                 RLC(output, randomness).value,
             )
@@ -202,7 +202,7 @@ class SignVerifyGadget:
         )
         keccak_table.lookup(
             is_enabled,
-            RLC(bytes(reversed(pub_key_bytes)), randomness).value,
+            RLC(bytes(reversed(pub_key_bytes)), randomness, n_bytes=64).value,
             FQ(64) * is_enabled,
             self.pub_key_hash.value,
             assert_msg,


### PR DESCRIPTION
Today I merged https://github.com/appliedzkp/zkevm-specs/pull/150 and I broke the tests in master.  This is the fix