### PR TITLE
Add CODEOWNERS file to repo to automatically assign reviewers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @appliedzkp/zkevm-reviewers


### PR DESCRIPTION
Follows the rationale of https://github.com/appliedzkp/zkevm-circuits/pull/429